### PR TITLE
Fix staging environment URL

### DIFF
--- a/spec/javascripts/popup_view_spec.js
+++ b/spec/javascripts/popup_view_spec.js
@@ -70,7 +70,7 @@ describe("PopupView", function() {
       expect(envs.map(fn('url'))).toEqual([
         'https://www.gov.uk/browse/disabilities?foo=bar',
         'http://www.dev.gov.uk/browse/disabilities?foo=bar',
-        'https://www.staging.publishing.service.gov.uk/browse/disabilities?foo=bar',
+        'https://www-origin.staging.publishing.service.gov.uk/browse/disabilities?foo=bar',
         'https://www-origin.integration.publishing.service.gov.uk/browse/disabilities?foo=bar',
         'https://www-origin.publishing.service.gov.uk/browse/disabilities?foo=bar',
       ])
@@ -84,7 +84,7 @@ describe("PopupView", function() {
       expect(envs.map(fn('url'))).toEqual([
         'https://www.gov.uk/browse/disabilities?foo=bar',
         'http://www.dev.gov.uk/browse/disabilities?foo=bar',
-        'https://www.staging.publishing.service.gov.uk/browse/disabilities?foo=bar',
+        'https://www-origin.staging.publishing.service.gov.uk/browse/disabilities?foo=bar',
         'https://www-origin.integration.publishing.service.gov.uk/browse/disabilities?foo=bar',
         'https://www-origin.publishing.service.gov.uk/browse/disabilities?foo=bar',
       ])

--- a/src/menu/popup_view.js
+++ b/src/menu/popup_view.js
@@ -30,10 +30,10 @@ Popup.generateEnvironmentLinks = function(location) {
       host: "http://www.dev.gov.uk"
     },
     {
-      name: "Staging",
+      name: "Staging (origin)",
       protocol: "https",
       serviceDomain: "staging.publishing.service.gov.uk",
-      host: "https://www.staging.publishing.service.gov.uk"
+      host: "https://www-origin.staging.publishing.service.gov.uk"
     },
     {
       name: "Integration",

--- a/src/popup.html
+++ b/src/popup.html
@@ -8,7 +8,7 @@
   <link href="menu/reset.css" rel="stylesheet" type="text/css">
   <link href="menu/menu.css" rel="stylesheet" type="text/css">
 </head>
-<body style="width: 500px;">
+<body style="width: 550px;">
   <script id="template" type="x-tmpl-mustache">
     <div class='envs'>
       {{#environments}}


### PR DESCRIPTION
The old 'www.staging.publishing.service.gov.uk' URL no longer works as it has been removed from Fastly.

Updated to point to 'www-origin.'