### PR TITLE
Allow switching to the National Archives

### DIFF
--- a/spec/javascripts/popup_view_spec.js
+++ b/spec/javascripts/popup_view_spec.js
@@ -128,6 +128,14 @@ describe("PopupView", function() {
 
       expect(forProd[0].class).toEqual("current")
     })
+
+    it("returns nothing if not on GOV.UK", function () {
+      var links = Popup.generateEnvironmentLinks(
+        stubLocation("http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk/jobsearch")
+      );
+
+      expect(links).toEqual({ name: 'GOV.UK', url: 'https://www.gov.uk' })
+    })
   })
 
   describe("generateContentLinks", function () {

--- a/spec/javascripts/popup_view_spec.js
+++ b/spec/javascripts/popup_view_spec.js
@@ -59,6 +59,12 @@ describe("PopupView", function() {
 
       expect(path).toBe("/browse/disabilities")
     })
+
+    it("returns the path for national archives pages", function () {
+      var path = Popup.extractPath(stubLocation("http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk/some/page"))
+
+      expect(path).toBe("/some/page")
+    })
   })
 
   describe("generateEnvironmentLinks", function () {
@@ -121,6 +127,24 @@ describe("PopupView", function() {
       );
 
       expect(forProd[0].class).toEqual("current")
+    })
+  })
+
+  describe("generateContentLinks", function () {
+    it("returns the correct URLs", function () {
+      var links = Popup.generateContentLinks(
+        stubLocation("https://www.gov.uk/browse/disabilities?foo=bar")
+      )
+
+      expect(links.map(fn('url'))).toEqual([
+        'https://www.gov.uk/browse/disabilities',
+        'https://www.gov.uk/api/content/browse/disabilities',
+        'https://www.gov.uk/api/incoming-links/browse/disabilities?types[]=mainstream_browse_pages&types[]=topics&types[]=organisations&types[]=alpha_taxons',
+        'https://www.gov.uk/api/search.json?filter_link=/browse/disabilities',
+        'https://www.gov.uk/info/browse/disabilities',
+        'https://www.gov.uk/api/browse/disabilities.json',
+        'http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk/browse/disabilities'
+      ])
     })
   })
 

--- a/src/menu/popup_view.js
+++ b/src/menu/popup_view.js
@@ -78,6 +78,8 @@ Popup.extractPath = function(location) {
 
   if (location.href.match(/api\/content/)) {
     extractedPath = location.pathname.replace('api/content/', '');
+  } else if (location.href.match(/nationalarchives.gov.uk/)) {
+    extractedPath = location.pathname.split('https://www.gov.uk')[1];
   } else if (location.href.match(/api\/incoming-links/)) {
     extractedPath = location.pathname.replace('api/incoming-links/', '');
   } else if (location.href.match(/search.json/)) {
@@ -103,13 +105,20 @@ Popup.generateContentLinks = function(location) {
     return [];
   }
 
+  var originHost = location.origin;
+
+  if (originHost == 'http://webarchive.nationalarchives.gov.uk') {
+    originHost = "https://www.gov.uk"
+  }
+
   var links = [
-    { name: "On GOV.UK", url: location.origin + path },
-    { name: "Content item (JSON)", url: location.origin + "/api/content" + path },
-    { name: "Incoming links (JSON)", url: location.origin + "/api/incoming-links" + path + '?types[]=mainstream_browse_pages&types[]=topics&types[]=organisations&types[]=alpha_taxons'},
-    { name: "View search data", url: location.origin + "/api/search.json?filter_link=" + path },
-    { name: "Info page (not always available)", url: location.origin + "/info" + path },
-    { name: "Content API (JSON, deprecated)", url: location.origin + "/api" + path + ".json" },
+    { name: "On GOV.UK", url: originHost + path },
+    { name: "Content item (JSON)", url: originHost + "/api/content" + path },
+    { name: "Incoming links (JSON)", url: originHost + "/api/incoming-links" + path + '?types[]=mainstream_browse_pages&types[]=topics&types[]=organisations&types[]=alpha_taxons'},
+    { name: "View search data", url: originHost + "/api/search.json?filter_link=" + path },
+    { name: "Info page (not always available)", url: originHost + "/info" + path },
+    { name: "Content API (JSON, deprecated)", url: originHost + "/api" + path + ".json" },
+    { name: "National Archives", url: "http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk" + path },
   ]
 
   return links.map(function (link) {

--- a/src/menu/popup_view.js
+++ b/src/menu/popup_view.js
@@ -96,7 +96,7 @@ Popup.extractPath = function(location) {
     extractedPath = location.pathname.split('https://www.gov.uk')[1];
   } else if (location.href.match(/api\/incoming-links/)) {
     extractedPath = location.pathname.replace('api/incoming-links/', '');
-  } else if (location.href.match(/search.json/)) {
+  } else if (location.href.match(/api\/search.json/)) {
     extractedPath = location.href.split('filter_link=')[1];
   } else if (location.href.match(/info/)) {
     extractedPath = location.pathname.replace('info/', '');

--- a/src/menu/popup_view.js
+++ b/src/menu/popup_view.js
@@ -16,6 +16,20 @@ Popup.createView = function(location, renderingAppName) {
 // Returns a hash with envs, including one with `class: "current"` to show
 // the current environment.
 Popup.generateEnvironmentLinks = function(location) {
+
+  function isPartOfGOVUK() {
+    return location.host.match(/www.gov.uk/) ||
+        location.host.match(/publishing.service.gov.uk/) ||
+        location.host.match(/dev.gov.uk/);
+  }
+
+  if (!isPartOfGOVUK()) {
+    return {
+      name: "GOV.UK",
+      url: "https://www.gov.uk"
+    }
+  }
+
   var ENVIRONMENTS = [
     {
       name: "Production",


### PR DESCRIPTION
The National Archives keeps a history of GOV.UK. This commit adds support for switching between the current site and the index page for the URL on http://webarchive.nationalarchives.gov.uk/.