### PR TITLE
Add link to draft version of item

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,15 @@ Source: [Getting Started: Building a Chrome Extension](https://developer.chrome.
 
 ### Running the tests
 
-Run the Jasmine test suite with:
+In development it's easiest to run:
+
+```
+$ bundle exec rake jasmine
+```
+
+This will start a server on http://localhost:8888/ that serves the tests.
+
+You can also run the Jasmine test suite in slower "headless" mode with:
 
 ```
 $ bundle exec rake jasmine:ci

--- a/spec/javascripts/content_links_spec.js
+++ b/spec/javascripts/content_links_spec.js
@@ -1,7 +1,10 @@
 describe("PopupView.generateContentLinks", function () {
+  var PROD_ENV = { protocol: 'https', serviceDomain: 'publishing.service.gov.uk' }
+
   it("returns the correct URIs", function () {
     var links = Popup.generateContentLinks(
-      stubLocation("https://www.gov.uk/browse/disabilities?foo=bar")
+      stubLocation("https://www.gov.uk/browse/disabilities?foo=bar"),
+      PROD_ENV
     )
 
     var urls = pluck(links, 'url')
@@ -12,13 +15,28 @@ describe("PopupView.generateContentLinks", function () {
       'https://www.gov.uk/api/search.json?filter_link=/browse/disabilities',
       'https://www.gov.uk/info/browse/disabilities',
       'https://www.gov.uk/api/browse/disabilities.json',
+      'https://draft-origin.publishing.service.gov.uk/browse/disabilities',
       'http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk/browse/disabilities'
     ])
   })
 
+  it("returns the draft URIs for non-prod environments", function () {
+    var links = Popup.generateContentLinks(
+      stubLocation("https://www.gov.uk/browse/disabilities?foo=bar"),
+      { protocol: 'https', serviceDomain: 'staging.publishing.service.gov.uk'}
+    )
+
+    var urls = pluck(links, 'url')
+
+    expect(urls).toContain(
+      'https://draft-origin.staging.publishing.service.gov.uk/browse/disabilities'
+    )
+  })
+
   it("does not generate URIs for the root page", function () {
     var links = Popup.generateContentLinks(
-      stubLocation("https://www.gov.uk/")
+      stubLocation("https://www.gov.uk/"),
+      PROD_ENV
     )
 
     expect(links).toEqual([])
@@ -26,7 +44,8 @@ describe("PopupView.generateContentLinks", function () {
 
   it("does not generate URIs for publishing apps (non-www pages)", function () {
     var links = Popup.generateContentLinks(
-      stubLocation("https://search-admin.publishing.service.gov.uk/queries")
+      stubLocation("https://search-admin.publishing.service.gov.uk/queries"),
+      PROD_ENV
     )
 
     expect(links).toEqual([])

--- a/spec/javascripts/extract_path_spec.js
+++ b/spec/javascripts/extract_path_spec.js
@@ -1,8 +1,14 @@
 describe("Popup.extractPath", function () {
-  it("returns nothing for non-frontend URLs", function () {
+  it("returns nothing for publishing applications", function () {
     var path = Popup.extractPath(stubLocation("https://publisher.publishing.service.gov.uk/foo/bar"))
 
     expect(path).toBeUndefined();
+  })
+
+  it("returns the path for draft URLs", function () {
+    var path = Popup.extractPath(stubLocation("https://draft-origin.staging.publishing.service.gov.uk/browse/disabilities"))
+
+    expect(path).toEqual("/browse/disabilities");
   })
 
   it("returns the path for frontend applications", function () {

--- a/src/popup/content_links.js
+++ b/src/popup/content_links.js
@@ -1,7 +1,7 @@
 var Popup = Popup || {};
 
 // Given a location, generate links to different content presentations
-Popup.generateContentLinks = function(location) {
+Popup.generateContentLinks = function(location, currentEnvironment) {
   var path = Popup.extractPath(location);
 
   // If no path can be found (which means we're probably in a publishing app)
@@ -17,7 +17,7 @@ Popup.generateContentLinks = function(location) {
   // This is 'https://www.gov.uk' or 'https://www-origin.integration.publishing.service.gov.uk/', etc.
   var originHost = location.origin;
 
-  if (originHost == 'http://webarchive.nationalarchives.gov.uk') {
+  if (originHost == 'http://webarchive.nationalarchives.gov.uk' || originHost.match(/draft-origin/)) {
     originHost = "https://www.gov.uk"
   }
 
@@ -27,6 +27,7 @@ Popup.generateContentLinks = function(location) {
     { name: "Search data (JSON)", url: originHost + "/api/search.json?filter_link=" + path },
     { name: "Info page (not always available)", url: originHost + "/info" + path },
     { name: "Content API (JSON, deprecated)", url: originHost + "/api" + path + ".json" },
+    { name: "Draft (may not always work)", url: currentEnvironment.protocol + '://draft-origin.' + currentEnvironment.serviceDomain + path },
     { name: "National Archives", url: "http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk" + path },
   ]
 

--- a/src/popup/extract_path.js
+++ b/src/popup/extract_path.js
@@ -15,7 +15,7 @@ Popup.extractPath = function(location) {
     extractedPath = location.pathname.replace('info/', '');
   } else if (location.href.match(/api.*\.json/)) {
     extractedPath = location.pathname.replace('api/', '').replace('.json', '');
-  } else if (location.href.match(/www/)) {
+  } else if (location.href.match(/www/) || location.href.match(/draft-origin/)) {
     extractedPath = location.pathname;
   }
 

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -78,8 +78,8 @@ var Popup = Popup || {};
   // app and creates an object with all URLs and other view data to render the
   // pop.
    function createView(location) {
-    var contentLinks = Popup.generateContentLinks(location),
-        environment = Popup.environment(location);
+    var environment = Popup.environment(location);
+    var contentLinks = Popup.generateContentLinks(location, environment.currentEnvironment);
 
     return {
       environments: environment.allEnvironments,


### PR DESCRIPTION
`draft-origin` is able to serve pages from the draft content-store for some formats:

https://www.gov.uk/browse/education
https://draft-origin.publishing.service.gov.uk/browse/education

<img width="1394" alt="screen shot 2016-06-07 at 16 45 21" src="https://cloud.githubusercontent.com/assets/233676/15864492/449bbe0a-2ccf-11e6-83fc-5faa4eab7718.png">

On certain pages the draft stack will error (search for example, because there's no draft-search).