### PR TITLE
Add link for viewing smart answer govspeak 

### DIFF
--- a/spec/javascripts/content_tools_links_spec.js
+++ b/spec/javascripts/content_tools_links_spec.js
@@ -1,0 +1,37 @@
+describe("PopupView.generateContentLinks", function () {
+  var PROD_ENV = { protocol: 'https', serviceDomain: 'integration.publishing.service.gov.uk' }
+
+  it("returns the correct URIs", function () {
+    var fakeSuccess = {
+        base_path: "/marriage-abroad",
+        content_id: "uyre74734-7434783473-87857454jyreure",
+        document_type: "smartanswer_document",
+        first_published_at: "2016-02-29T09:24:10.000+00:00",
+        format: "placeholder_smart_answer",
+        locale: "en",
+        phase: "live",
+        public_updated_at: "2016-08-19T12:12:28.000+00:00",
+        publishing_app: "smartanswers",
+        rendering_app: "smartanswers",
+        schema_name: "placeholder_smart_answer",
+        title: "Getting married abroad",
+        updated_at: "2016-08-19T12:12:28.379Z"
+      };
+
+    // TODO: need to get this tests working by faking the success json response.
+    spyOn($, "getJSON").and.callThrough(function(params) {
+      params.success(fakeSuccess);
+    });
+
+    var contentItemLinks = Popup.generateContentToolsLinks("https://www-origin.integration.publishing.service.gov.uk/api/content/marriage-abroad/y/american-samoa",
+      PROD_ENV
+    )
+
+    var urls = pluck(contentItemLinks.links, "url")
+
+    expect(urls).toEqual([
+      "https://www-origin.integration.publishing.service.gov.uk/marriage-abroad/y/american-samoa.txt",
+      "https://www-origin.integration.publishing.service.gov.uk/marriage-abroad/visualise"
+    ])
+  })
+});

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -1,6 +1,7 @@
 src_files:
     - src/popup/lib/jquery.min.js
     - src/popup/content_links.js
+    - src/popup/content_tools_links.js
     - src/popup/environment.js
     - src/popup/extract_path.js
     - src/popup/external_links.js

--- a/src/popup.html
+++ b/src/popup.html
@@ -5,6 +5,7 @@
   <script src='popup/lib/jquery.min.js'></script>
 
   <script src='popup/content_links.js'></script>
+  <script src='popup/content_tools_links.js'></script>
   <script src='popup/environment.js'></script>
   <script src='popup/external_links.js'></script>
   <script src='popup/extract_path.js'></script>
@@ -22,6 +23,7 @@
     </div>
 
     <ul class='content-links'>{{#contentLinks}}<li><a href="{{url}}" class="{{class}}">{{name}}</a></li>{{/contentLinks}}</ul>
+    <ul class='content-tools-links'>{{#contentToolsLinks}}<li><a href="{{url}}" class="contenttools">{{{name}}}</a></li>{{/contentToolsLinks}}</ul>
     <ul class='external-links'>{{#externalLinks}}<li><a href="{{url}}" class="external">{{{name}}}</a></li>{{/externalLinks}}</ul>
   </script>
 

--- a/src/popup/content_tools_links.js
+++ b/src/popup/content_tools_links.js
@@ -1,0 +1,19 @@
+var Popup = Popup || {};
+
+// Contains links to content tools like SmartAnswers etc.
+Popup.generateContentToolsLinks = function(contentStoreURL, env) {
+  var links = [];
+  var baseURL = contentStoreURL.replace(/\/y\/?.*/, '');
+  var contentItem = {}
+  $.ajaxSetup({ async: false });
+  $.getJSON(baseURL, function(contentStoreData) {
+    contentItem = contentStoreData;
+    if (contentItem.rendering_app == "smartanswers") {
+      links.push(
+        { name: "SmartAnswers: Display GovSpeak", url: env.url + ".txt"},
+        { name: "SmartAnswers: Display Visualise", url: env.host + contentItem.base_path + "/visualise"}
+      );
+    }
+  });
+  return { contentItem: contentItem, links: links };
+}

--- a/src/popup/extract_path.js
+++ b/src/popup/extract_path.js
@@ -15,6 +15,10 @@ Popup.extractPath = function(location) {
     extractedPath = location.pathname.replace('info/', '');
   } else if (location.href.match(/api.*\.json/)) {
     extractedPath = location.pathname.replace('api/', '').replace('.json', '');
+  } else if (location.href.match(/\.txt$/)) {
+    extractedPath = location.pathname.replace('.txt', '');
+  } else if (location.href.match(/\/visualise\/?$/)) {
+    extractedPath = location.pathname.replace('/visualise', '');
   } else if (location.href.match(/www/) || location.href.match(/draft-origin/)) {
     extractedPath = location.pathname;
   }

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -19,13 +19,13 @@ body {
   background-color: #005ea5;
 }
 
-.external-links {
+.external-links, .content-tools-links {
   margin-top: 10px;
   padding-top: 10px;
   border-top: 1px solid #ccc;
 }
 
-.external-links:empty {
+.external-links:empty, .content-tools-links:empty {
   display: none;
 }
 

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -31,8 +31,16 @@ var Popup = Popup || {};
 
     if (contentStore) {
       // Request the content item to add some extra links.
-      $.getJSON(contentStore.url, function(contentStoreData) {
-        view.externalLinks = Popup.generateExternalLinks(contentStoreData, view.currentEnvironment);
+      $.getJSON(contentStore.url).complete(function(contentStoreData){
+        var contentItem = contentStoreData.responseJSON;
+        if( typeof contentItem === 'undefined' && contentStore.url.match(/\/y\/?.*/) ) {
+          var contentItemLinks = Popup.generateContentToolsLinks(contentStore.url, view.currentEnvironment);
+          view.contentToolsLinks = contentItemLinks.links
+          view.externalLinks = Popup.generateExternalLinks(contentItemLinks.contentItem, view.currentEnvironment);
+        } else {
+          view.externalLinks = Popup.generateExternalLinks(contentItem, view.currentEnvironment);
+        }
+
         $('#content').html(Mustache.render(template, view));
         setupClicks();
       })


### PR DESCRIPTION
# WIP Don't merge

This PR adds the ability to view smart answers GovSpeak version.

Here I have added a link to the GOV.UK chrome extension that simply adds a '.txt' to the end of the user's current url.

This will then display the GovSpeak (Markdown) version of the page. This may not work for all urls and at the moment only supported by SmartAnswers.