### PR TITLE
Link to businesssupportfinder correctly

### DIFF
--- a/src/popup/external_links.js
+++ b/src/popup/external_links.js
@@ -9,7 +9,8 @@ Popup.generateExternalLinks = function(contentItem, env) {
     var APP_NAMES_TO_REPOS = {
       smartanswers: 'smart-answers',
       designprinciples: 'design-principles',
-      'whitehall-frontend': 'whitehall'
+      'whitehall-frontend': 'whitehall',
+      'businesssupportfinder': 'business-support-finder'
     }
 
     return APP_NAMES_TO_REPOS[appName] || appName;


### PR DESCRIPTION
Pages have `businesssupportfinder` rendering-app, but the repo is
`business-support-finder`.