### PR TITLE
Link correctly to placeholder schemas

### DIFF
--- a/spec/javascripts/external_links_spec.js
+++ b/spec/javascripts/external_links_spec.js
@@ -40,6 +40,18 @@ describe("Popup.generateExternalLinks", function () {
     })
   })
 
+  it("correctly links to placeholder schemas", function () {
+    var contentItem = {
+      schema_name: 'placeholder_something_or_other'
+    }
+
+    var links = Popup.generateExternalLinks(contentItem, PROD_ENV)
+
+    expect(links).toContain({
+      name: 'Content schema: placeholder <img src="popup/github.png" width="16" />',
+      url: 'https://github.com/alphagov/govuk-content-schemas/tree/master/dist/formats/placeholder'
+    })
+  })
 
   it("generates edit links for topics", function () {
     var contentItem = {

--- a/src/popup/external_links.js
+++ b/src/popup/external_links.js
@@ -18,6 +18,11 @@ Popup.generateExternalLinks = function(contentItem, env) {
 
   var links = [generateEditLink(contentItem, env)];
 
+  var schemaName = contentItem.schema_name || ""; 
+  if (schemaName.indexOf("placeholder") !== -1) {
+    schemaName = "placeholder"
+  }
+
   links.push({
     name: 'Look up in content-tagger',
     url: env.protocol + '://content-tagger.' + env.serviceDomain + '/content/' + contentItem.content_id,
@@ -39,8 +44,8 @@ Popup.generateExternalLinks = function(contentItem, env) {
   })
 
   links.push({
-    name: 'Content schema: ' + contentItem.schema_name + ' <img src="popup/github.png" width="16" />',
-    url: 'https://github.com/alphagov/govuk-content-schemas/tree/master/dist/formats/' + contentItem.schema_name
+    name: 'Content schema: ' + schemaName + ' <img src="popup/github.png" width="16" />',
+    url: 'https://github.com/alphagov/govuk-content-schemas/tree/master/dist/formats/' + schemaName
   })
 
   links.push({


### PR DESCRIPTION
Content items have either a named schema (like "detailed_guide") or a schema name that's prefixed by "placeholder" (like "placeholder_organisation").

This commit makes sure that we link to the `placeholder` content schema for placeholder things.