### PR TITLE
Add link to anonymous feedback explorer

### DIFF
--- a/spec/javascripts/content_links_spec.js
+++ b/spec/javascripts/content_links_spec.js
@@ -16,6 +16,7 @@ describe("PopupView.generateContentLinks", function () {
       'https://www.gov.uk/info/browse/disabilities',
       'https://www.gov.uk/api/browse/disabilities.json',
       'https://draft-origin.publishing.service.gov.uk/browse/disabilities',
+      'https://support.publishing.service.gov.uk/anonymous_feedback?path=/browse/disabilities',
       'http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk/browse/disabilities'
     ])
   })
@@ -54,5 +55,25 @@ describe("PopupView.generateContentLinks", function () {
     )
 
     expect(links).toEqual([])
+  })
+
+  it("only generates URLs for publishing-apps when it's the support application", function () {
+    var links = Popup.generateContentLinks(
+      stubLocation("https://support.publishing.service.gov.uk/anonymous_feedback?path=/browse/disabilities"),
+      PROD_ENV
+    )
+
+    var urls = pluck(links, 'url')
+
+    expect(urls).toEqual([
+      'https://www.gov.uk/browse/disabilities',
+      'https://www.gov.uk/api/content/browse/disabilities',
+      'https://www.gov.uk/api/search.json?filter_link=/browse/disabilities',
+      'https://www.gov.uk/info/browse/disabilities',
+      'https://www.gov.uk/api/browse/disabilities.json',
+      'https://draft-origin.publishing.service.gov.uk/browse/disabilities',
+      'https://support.publishing.service.gov.uk/anonymous_feedback?path=/browse/disabilities',
+      'http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk/browse/disabilities'
+    ])
   })
 })

--- a/src/popup/content_links.js
+++ b/src/popup/content_links.js
@@ -12,7 +12,7 @@ Popup.generateContentLinks = function(location, currentEnvironment, renderingApp
   // This is 'https://www.gov.uk' or 'https://www-origin.integration.publishing.service.gov.uk/', etc.
   var originHost = location.origin;
 
-  if (originHost == 'http://webarchive.nationalarchives.gov.uk' || originHost.match(/draft-origin/)) {
+  if (originHost == 'http://webarchive.nationalarchives.gov.uk' || originHost.match(/draft-origin/) || originHost.match(/support/)) {
     originHost = "https://www.gov.uk"
   }
 
@@ -27,6 +27,7 @@ Popup.generateContentLinks = function(location, currentEnvironment, renderingApp
     links.push({ name: "Info page (not always available)", url: originHost + "/info" + path })
     links.push({ name: "Content API (JSON, deprecated)", url: originHost + "/api" + path + ".json" })
     links.push({ name: "Draft (may not always work)", url: currentEnvironment.protocol + '://draft-origin.' + currentEnvironment.serviceDomain + path })
+    links.push({ name: "Anonymous feedback", url: currentEnvironment.protocol + '://support.' + currentEnvironment.serviceDomain + '/anonymous_feedback?path=' + path })
   }
 
   links.push({ name: "National Archives", url: "http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk" + path })

--- a/src/popup/extract_path.js
+++ b/src/popup/extract_path.js
@@ -8,6 +8,9 @@ Popup.extractPath = function(location, renderingApplication) {
   if (location.href.match(/api\/content/)) {
     extractedPath = location.pathname.replace('api/content/', '');
   }
+  else if (location.href.match(/anonymous_feedback/)) {
+    extractedPath = location.href.split('path=')[1];
+  }
   else if (location.href.match(/nationalarchives.gov.uk/)) {
     extractedPath = location.pathname.split('https://www.gov.uk')[1];
   }

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -31,7 +31,7 @@ body {
 
 li a {
   display: block;
-  padding: 10px;
+  padding: 9px 10px;
   color: #000;
   text-decoration: none;
 }


### PR DESCRIPTION
All pages on GOV.UK have a "Is there anything wrong with this page?" link. The feedback gathered from this is sent to the [support application](https://support.publishing.service.gov.uk).

This commit adds a deeplink to the support app for the current page.

<img width="1387" alt="screen shot 2016-09-26 at 22 45 31" src="https://cloud.githubusercontent.com/assets/233676/18853044/36a852ea-843b-11e6-9ba3-e2bf923ccbb6.png">
![screen shot 2016-09-26 at 22 45 36](https://cloud.githubusercontent.com/assets/233676/18853045/36afaa7c-843b-11e6-8664-3f32ad8220ba.png)
