### PR TITLE
The /info page almost always works

### DIFF
--- a/src/popup/content_links.js
+++ b/src/popup/content_links.js
@@ -24,7 +24,7 @@ Popup.generateContentLinks = function(location, currentEnvironment, renderingApp
   if (path != '/') {
     links.push({ name: "Content item (JSON)", url: originHost + "/api/content" + path })
     links.push({ name: "Search data (JSON)", url: originHost + "/api/search.json?filter_link=" + path })
-    links.push({ name: "Info page (not always available)", url: originHost + "/info" + path })
+    links.push({ name: "Info page", url: originHost + "/info" + path })
     links.push({ name: "Content API (JSON, deprecated)", url: originHost + "/api" + path + ".json" })
     links.push({ name: "Draft (may not always work)", url: currentEnvironment.protocol + '://draft-origin.' + currentEnvironment.serviceDomain + path })
   }


### PR DESCRIPTION
Since info-frontend was made to work with data from the content-store, the /info page works for everything that's in the content-store (+99% now).