### PR TITLE
Add visualise link for SmartAnswers

### DIFF
--- a/spec/javascripts/content_tools_links_spec.js
+++ b/spec/javascripts/content_tools_links_spec.js
@@ -1,24 +1,24 @@
 describe("PopupView.generateContentToolsLinks", function () {
-  var renderingApplication = "smartanswers";
-  var PROD_ENV = {}
+  describe("on a SmartAnswers question or outcome", function () {
+    var contentToolsLinks = Popup.generateContentToolsLinks("smartanswers", { url: "https://www.gov.uk/smart-answer/y/question-1" });
+    var contentToolsURLs = contentToolsLinks.map(function (link) { return link.url; });
 
-  it("returns the URL to the GovSpeak file", function () {
-    PROD_ENV.url = "https://www.gov.uk/smart-answer/y/question-1";
-    contentToolsLinks = Popup.generateContentToolsLinks(renderingApplication, PROD_ENV)
-
-    expect(contentToolsLinks[0].url).toEqual(PROD_ENV.url + ".txt")
+    it("generates a GovSpeak link", function () {
+      expect(contentToolsURLs).toContain("https://www.gov.uk/smart-answer/y/question-1.txt");
+    });
   });
 
-  it("does not add a link to the GovSpeak of landing pages", function () {
-    PROD_ENV.url = "https://www.gov.uk/smart-answer";
-    contentToolsLinks = Popup.generateContentToolsLinks(renderingApplication, PROD_ENV)
+  describe("on a SmartAnswers landing page", function () {
+    var contentToolsLinks = Popup.generateContentToolsLinks("smartanswers", { url: "https://www.gov.uk/smart-answer" });
+    var contentToolsURLs = contentToolsLinks.map(function (link) { return link.url; });
 
-    expect(contentToolsLinks).toEqual([])
+    it("does not generate a GovSpeak link", function () {
+      expect(contentToolsURLs).not.toContain("https://www.gov.uk/smart-answer.txt");
+    });
   });
 
-  it("does not add a link to GovSpeak for other non-smartanswer pages", function () {
-    PROD_ENV.url = "https://wwww.gov.uk/not-a-smartanswer";
-    contentToolsLinks = Popup.generateContentToolsLinks("something-else", PROD_ENV)
+  it("does not add content tools links on non-SmartAnswers pages", function () {
+    var contentToolsLinks = Popup.generateContentToolsLinks("something-else", { url: "https://wwww.gov.uk/not-a-smartanswer" });
 
     expect(contentToolsLinks).toEqual([])
   });

--- a/spec/javascripts/content_tools_links_spec.js
+++ b/spec/javascripts/content_tools_links_spec.js
@@ -6,6 +6,10 @@ describe("PopupView.generateContentToolsLinks", function () {
     it("generates a GovSpeak link", function () {
       expect(contentToolsURLs).toContain("https://www.gov.uk/smart-answer/y/question-1.txt");
     });
+
+    it("generates a visualise link", function () {
+      expect(contentToolsURLs).toContain("https://www.gov.uk/smart-answer/visualise");
+    });
   });
 
   describe("on a SmartAnswers landing page", function () {
@@ -14,6 +18,10 @@ describe("PopupView.generateContentToolsLinks", function () {
 
     it("does not generate a GovSpeak link", function () {
       expect(contentToolsURLs).not.toContain("https://www.gov.uk/smart-answer.txt");
+    });
+
+    it("generates a visualise link", function () {
+      expect(contentToolsURLs).toContain("https://www.gov.uk/smart-answer/visualise");
     });
   });
 

--- a/src/popup/content_tools_links.js
+++ b/src/popup/content_tools_links.js
@@ -4,9 +4,15 @@ var Popup = Popup || {};
 Popup.generateContentToolsLinks = function(renderingApplication, env) {
   var links = [];
 
-  if (renderingApplication == "smartanswers" && isNotSmartAnswerLandingPage(env.url)) {
+  if (renderingApplication == "smartanswers") {
+    if (isNotSmartAnswerLandingPage(env.url)) {
+      links.push(
+        { name: "SmartAnswers: Display GovSpeak", url: env.url + ".txt"}
+      );
+    }
+
     links.push(
-      { name: "SmartAnswers: Display GovSpeak", url: env.url + ".txt"}
+      { name: "SmartAnswers: Visualise", url: env.url.replace(/\/y.*$/, "") + "/visualise" }
     );
   }
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/JHMfhXJa)

[SmartAnswers](https://github.com/alphagov/smart-answers) includes a visualise tool to allow content designers to see how the questions and outcomes in a smart answer relate to each other.

This PR adds a link to view the flow visualisation for the current page, if the current page is a smart answer.

<img width="998" alt="screen shot 2016-09-27 at 14 24 10" src="https://cloud.githubusercontent.com/assets/657807/18875533/1aa4c906-84be-11e6-8bff-388a6c6080d2.png">