### PR TITLE
Don't rely on jQuery being present

### DIFF
--- a/src/fetch-page-data.js
+++ b/src/fetch-page-data.js
@@ -5,5 +5,10 @@
 chrome.runtime.sendMessage({
   action: "populatePopup",
   currentLocation: window.location,
-  renderingApplication: $('meta[name="govuk:rendering-application"]').attr('content'),
+  renderingApplication: getMetatag('govuk:rendering-application'),
 });
+
+function getMetatag(name) {
+  var meta = document.getElementsByTagName('meta')[name]
+  return meta && meta.getAttribute('content')
+}


### PR DESCRIPTION
This script is executed in the main browser thread, not inside the popup. This means it won't necessarily have access to jQuery, since the page where it's executed could be erroring, or just not have it installed.