### PR TITLE
Remove 'tabs' permission

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -19,7 +19,6 @@
     "128": "icons/128.png"
   },
   "permissions": [
-    "tabs",
     "http://*.gov.uk/*",
     "https://*.gov.uk/*"
   ],


### PR DESCRIPTION
This 'tabs' permission is quite powerful but it shouldn't be needed for
this plugin. Chrome docs say:

 The majority of the chrome.tabs API can be used without declaring any
 permission. However, the "tabs" permission is required in order to
 populate the url, title, and favIconUrl properties of Tab.

  https://developer.chrome.com/extensions/tabs

I believe the functionality of the extension only reads from these
properties and doesn't need to populate any of them.