### PR TITLE
Release 1.5.0

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "name": "GOV.UK Toolkit",
   "description": "Switch between GOV.UK environments and content",
   "homepage_url": "https://github.com/alphagov/govuk-toolkit-chrome",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "content_scripts": [
     {
       "matches": ["https://*.gov.uk/*"],


### PR DESCRIPTION
- Better support for mainstream pages (https://github.com/alphagov/govuk-toolkit-chrome/pull/33)
- Manuals now correctly link to manuals publisher (https://github.com/alphagov/govuk-toolkit-chrome/pull/34)
- Extension now requests less permissions (https://github.com/alphagov/govuk-toolkit-chrome/pull/36)