### PR TITLE
Fixes content api url for /done/pay-dvla-fine

### DIFF
--- a/spec/javascripts/content_links_spec.js
+++ b/spec/javascripts/content_links_spec.js
@@ -91,6 +91,20 @@ describe("PopupView.generateContentLinks", function () {
     )
   })
 
+  it("generates the correct content api DVLA url", function () {
+    var links = Popup.generateContentLinks(
+      stubLocation("https://www.gov.uk/done/pay-dvla-fine"),
+      PROD_ENV,
+      "frontend"
+    )
+
+    var urls = pluck(links, 'url')
+
+    expect(urls).toContain(
+      "https://www.gov.uk/api/content/done/pay-dvla-fine"
+    )
+  });
+
   it("generates correct mainstream content store URL", function () {
     var links = Popup.generateContentLinks(
       stubLocation("https://www.gov.uk/holiday-entitlement-rights/holiday-pay-the-basics"),

--- a/src/popup/content_links.js
+++ b/src/popup/content_links.js
@@ -23,7 +23,9 @@ Popup.generateContentLinks = function(location, currentEnvironment, renderingApp
 
   if (renderingApplication == "smartanswers") {
     var contentStoreUrl = originHost + "/api/content" + path.replace(/\/y\/?.*$/, '');
-  } else if (renderingApplication == "frontend") {
+  } else if (path.split('/')[1] == "done" && renderingApplication == "frontend")
+    var contentStoreUrl = originHost + "/api/content" + path;
+  else if (renderingApplication == "frontend") {
     var contentStoreUrl = originHost + "/api/content/" + path.split('/')[1];
   } else {
     var contentStoreUrl = originHost + "/api/content" + path;


### PR DESCRIPTION
When selecting "Content Item" from https://www.gov.uk/done/pay-dvla-fine
it was sending the user to https://www.gov.uk/api/content/done instead
of https://www.gov.uk/api/content/done/pay-dvla-fine

This commit aims to solve that issue.

![screen shot 2016-12-02 at 00 10 08](https://cloud.githubusercontent.com/assets/136777/20818158/c125508c-b823-11e6-9f92-34cd6208f07b.png)
![screen shot 2016-12-02 at 00 10 21](https://cloud.githubusercontent.com/assets/136777/20818157/c122e6e4-b823-11e6-8592-2c6e635bc2db.png)

