### PR TITLE
Rename anonymous feedback to user feedback

### DIFF
--- a/src/popup/content_links.js
+++ b/src/popup/content_links.js
@@ -37,7 +37,7 @@ Popup.generateContentLinks = function(location, currentEnvironment, renderingApp
     links.push({ name: "Info page", url: originHost + "/info" + path })
     links.push({ name: "Content API (JSON, deprecated)", url: originHost + "/api" + path + ".json" })
     links.push({ name: "Draft (may not always work)", url: currentEnvironment.protocol + '://draft-origin.' + currentEnvironment.serviceDomain + path })
-    links.push({ name: "Anonymous feedback", url: currentEnvironment.protocol + '://support.' + currentEnvironment.serviceDomain + '/anonymous_feedback?path=' + path })
+    links.push({ name: "User feedback", url: currentEnvironment.protocol + '://support.' + currentEnvironment.serviceDomain + '/anonymous_feedback?path=' + path })
   }
 
   links.push({ name: "National Archives", url: "http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk" + path })


### PR DESCRIPTION
“User feedback” is more obvious than “Anonymous feedback”.