### PR TITLE
Fix content api url for help pages

### DIFF
--- a/spec/javascripts/content_links_spec.js
+++ b/spec/javascripts/content_links_spec.js
@@ -105,6 +105,20 @@ describe("PopupView.generateContentLinks", function () {
     )
   });
 
+  it("generates the correct content api for help pages", function () {
+    var links = Popup.generateContentLinks(
+      stubLocation("https://www.gov.uk/help/cookies"),
+      PROD_ENV,
+      "frontend"
+    )
+
+    var urls = pluck(links, 'url')
+
+    expect(urls).toContain(
+      "https://www.gov.uk/api/content/help/cookies"
+    )
+  });
+
   it("generates correct mainstream content store URL", function () {
     var links = Popup.generateContentLinks(
       stubLocation("https://www.gov.uk/holiday-entitlement-rights/holiday-pay-the-basics"),

--- a/src/popup/content_links.js
+++ b/src/popup/content_links.js
@@ -23,10 +23,12 @@ Popup.generateContentLinks = function(location, currentEnvironment, renderingApp
 
   if (renderingApplication == "smartanswers") {
     var contentStoreUrl = originHost + "/api/content" + path.replace(/\/y\/?.*$/, '');
-  } else if (path.split('/')[1] == "done" && renderingApplication == "frontend")
-    var contentStoreUrl = originHost + "/api/content" + path;
-  else if (renderingApplication == "frontend") {
-    var contentStoreUrl = originHost + "/api/content/" + path.split('/')[1];
+  } else if (renderingApplication == "frontend") {
+    if (path.split('/')[1] == "done" || path.split('/')[1] == "help") {
+      var contentStoreUrl = originHost + "/api/content" + path;
+    } else {
+      var contentStoreUrl = originHost + "/api/content/" + path.split('/')[1];
+    }
   } else {
     var contentStoreUrl = originHost + "/api/content" + path;
   }


### PR DESCRIPTION
When selecting "Content Item" from https://www.gov.uk/help/cookies
it was sending the user to https://www.gov.uk/api/content/help instead
of https://www.gov.uk/api/content/help/cookies

This commit aims to solve that issue.
Inspired by https://github.com/alphagov/govuk-toolkit-chrome/pull/39

See https://github.com/alphagov/govuk-toolkit-chrome/issues/40