### PR TITLE
Display active A/B tests, with current variant highlighted

### DIFF
--- a/spec/javascripts/ab_tests_spec.js
+++ b/spec/javascripts/ab_tests_spec.js
@@ -1,0 +1,52 @@
+describe("Popup.findActiveAbTests", function () {
+  it("returns no A/B tests if none are active", function () {
+    var abTests = Popup.findActiveAbTests({});
+
+    expect(abTests).toEqual([]);
+  });
+
+  it("finds all A/B tests", function () {
+    var abTests = Popup.findActiveAbTests({
+      "first-AB-test-name": "some-value",
+      "second-AB-test-name": "other-value",
+      "third-AB-test-name": "yet-another-value",
+    });
+
+    expect(abTests.length).toEqual(3);
+    expect(abTests[0].name).toEqual("first-AB-test-name");
+    expect(abTests[1].name).toEqual("second-AB-test-name");
+    expect(abTests[2].name).toEqual("third-AB-test-name");
+  });
+
+  it("returns A and B buckets", function () {
+    var abTests = Popup.findActiveAbTests({
+      "some-AB-test-name": "some-value"
+    });
+
+    expect(abTests[0].buckets.length).toEqual(2);
+    expect(abTests[0].buckets[0].name).toEqual("A");
+    expect(abTests[0].buckets[1].name).toEqual("B");
+  });
+
+  it("highlights 'A' bucket if user is in 'A' group", function () {
+    var abTests = Popup.findActiveAbTests({
+      "some-AB-test-name": "B",
+      "other-AB-test-name": "A"
+    });
+
+    expect(abTests[0].buckets[0].class).toEqual("");
+    expect(abTests[0].buckets[1].class).toEqual("ab-bucket-selected");
+
+    expect(abTests[1].buckets[0].class).toEqual("ab-bucket-selected");
+    expect(abTests[1].buckets[1].class).toEqual("");
+  });
+
+  it("doesn't highlight any buckets if variant is unknown", function () {
+    var abTests = Popup.findActiveAbTests({
+      "some-AB-test-name": "some-unknown-bucket"
+    });
+
+    expect(abTests[0].buckets[0].class).toEqual("");
+    expect(abTests[0].buckets[1].class).toEqual("");
+  });
+});

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -1,5 +1,6 @@
 src_files:
     - src/popup/lib/jquery.min.js
+    - src/popup/ab_tests.js
     - src/popup/content_links.js
     - src/popup/environment.js
     - src/popup/extract_path.js

--- a/src/fetch-page-data.js
+++ b/src/fetch-page-data.js
@@ -6,9 +6,24 @@ chrome.runtime.sendMessage({
   action: "populatePopup",
   currentLocation: window.location,
   renderingApplication: getMetatag('govuk:rendering-application'),
+  abTestBuckets: getAbTestBuckets()
 });
 
 function getMetatag(name) {
   var meta = document.getElementsByTagName('meta')[name]
   return meta && meta.getAttribute('content')
+}
+
+function getAbTestBuckets() {
+  var abMetaTags = document.getElementsByTagName('meta');
+
+  var abMetaTagPattern = /govuk:ab-test:([\w-]+):current-bucket/;
+
+  return Object.keys(abMetaTags).filter(function (tagName) {
+    return tagName.match(abMetaTagPattern);
+  }).reduce(function (abTags, tagName) {
+    var abTestName = abMetaTagPattern.exec(tagName)[1];
+    abTags[abTestName] = abMetaTags[tagName].getAttribute('content');
+    return abTags;
+  }, {});
 }

--- a/src/popup.html
+++ b/src/popup.html
@@ -4,6 +4,7 @@
   <script src='popup/lib/mustache.min.js'></script>
   <script src='popup/lib/jquery.min.js'></script>
 
+  <script src='popup/ab_tests.js'></script>
   <script src='popup/content_links.js'></script>
   <script src='popup/environment.js'></script>
   <script src='popup/external_links.js'></script>
@@ -23,6 +24,22 @@
 
     <ul class='content-links'>{{#contentLinks}}<li><a href="{{url}}" class="{{class}}">{{name}}</a></li>{{/contentLinks}}</ul>
     <ul class='external-links'>{{#externalLinks}}<li><a href="{{url}}" class="external">{{{name}}}</a></li>{{/externalLinks}}</ul>
+
+    {{#abTests.length}}
+      <div class='ab-tests'>
+        <h1>A/B tests</h1>
+        <ul>
+        {{#abTests}}
+          <li>
+            <span class='ab-test-name'>{{name}}</span>
+            {{#buckets}}
+              <span class='ab-test-bucket {{class}}'>{{name}}</span>
+            {{/buckets}}
+          </li>
+        {{/abTests}}
+        </ul>
+      </div>
+    {{/abTests.length}}
   </script>
 
   <div id="content">Loading...</div>

--- a/src/popup/ab_tests.js
+++ b/src/popup/ab_tests.js
@@ -1,0 +1,20 @@
+var Popup = Popup || {};
+
+Popup.findActiveAbTests = function(abTestBuckets) {
+  const buckets = ["A", "B"];
+
+  return Object.keys(abTestBuckets).map(function (abTestName) {
+
+    var currentBucket = abTestBuckets[abTestName];
+
+    return {
+      name: abTestName,
+      buckets: buckets.map(function (bucketName) {
+        return {
+          name: bucketName,
+          class: currentBucket === bucketName ? "ab-bucket-selected" : ""
+        };
+      })
+    }
+  });
+};

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -45,3 +45,35 @@ li a:hover {
   background-color: #005ea5;
   color: #fff;
 }
+
+.ab-tests {
+  margin-top: 10px;
+  padding: 20px 0 20px 10px;
+  border-top: 1px solid #ccc;
+}
+
+.ab-tests h1 {
+  margin-bottom: 9px;
+}
+
+.ab-test-name, .ab-test-bucket {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.ab-test-name {
+  width: 250px;
+  padding: 9px 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ab-test-bucket {
+  padding: 7px 9px 7px 9px;
+}
+
+.ab-bucket-selected {
+  color: #fff;
+  background-color: #005ea5;
+}

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -15,14 +15,17 @@ var Popup = Popup || {};
   // render function.
   chrome.runtime.onMessage.addListener(function (request, _sender) {
     if (request.action == "populatePopup") {
-      renderPopup(request.currentLocation, request.renderingApplication);
+      renderPopup(
+        request.currentLocation,
+        request.renderingApplication,
+        request.abTestBuckets);
     }
   });
 
   // Render the popup.
-  function renderPopup(location, renderingApplication) {
+  function renderPopup(location, renderingApplication, abTestBuckets) {
     // Creates a view object with the data and render a template with it.
-    var view = createView(location, renderingApplication);
+    var view = createView(location, renderingApplication, abTestBuckets);
     var template = $('#template').html();
     $('#content').html(Mustache.render(template, view));
     setupClicks();
@@ -76,16 +79,18 @@ var Popup = Popup || {};
   // This is the view object. It takes a location and the name of the rendering
   // app and creates an object with all URLs and other view data to render the
   // pop.
-   function createView(location, renderingApplication) {
+   function createView(location, renderingApplication, abTestBuckets) {
     var environment = Popup.environment(location);
     var contentLinks = Popup.generateContentLinks(location, environment.currentEnvironment, renderingApplication);
+    var abTests = Popup.findActiveAbTests(abTestBuckets);
 
     return {
       environments: environment.allEnvironments,
       currentEnvironment: environment.currentEnvironment,
       contentLinks: contentLinks,
       // external links will be populated by a call to the content store
-      externalLinks: []
+      externalLinks: [],
+      abTests: abTests
     }
   }
 }());


### PR DESCRIPTION
Determine any A/B tests which are currently active, using the meta-tag which has been added to the page. Display this in the extension popup, making it clear which version of the page the user is seeing.

The A/B tests are added to the bottom of the extension's popup window:

<img width="553" alt="screen shot 2017-01-20 at 17 23 37" src="https://cloud.githubusercontent.com/assets/754712/22158733/9370fec8-df35-11e6-86bd-b165b4de8d9d.png">

If there are no active A/B tests, this section doesn't appear at all.

Note that this currently just displays the current A/B bucket. The next thing to do is add code to allow the user to change the bucket. I'm also planning to add a "Clear" button to remove the cookie or header, so the user can be reassigned to a random bucket.

Trello: https://trello.com/c/jra1OClm/320-make-it-easy-to-test-experiments-in-non-prod-environments