### PR TITLE
Allow users to select an A/B bucket on Integration and Staging

### DIFF
--- a/spec/javascripts/ab_tests_spec.js
+++ b/spec/javascripts/ab_tests_spec.js
@@ -13,9 +13,9 @@ describe("Popup.findActiveAbTests", function () {
     });
 
     expect(abTests.length).toEqual(3);
-    expect(abTests[0].name).toEqual("first-AB-test-name");
-    expect(abTests[1].name).toEqual("second-AB-test-name");
-    expect(abTests[2].name).toEqual("third-AB-test-name");
+    expect(abTests[0].testName).toEqual("first-AB-test-name");
+    expect(abTests[1].testName).toEqual("second-AB-test-name");
+    expect(abTests[2].testName).toEqual("third-AB-test-name");
   });
 
   it("returns A and B buckets", function () {
@@ -24,8 +24,8 @@ describe("Popup.findActiveAbTests", function () {
     });
 
     expect(abTests[0].buckets.length).toEqual(2);
-    expect(abTests[0].buckets[0].name).toEqual("A");
-    expect(abTests[0].buckets[1].name).toEqual("B");
+    expect(abTests[0].buckets[0].bucketName).toEqual("A");
+    expect(abTests[0].buckets[1].bucketName).toEqual("B");
   });
 
   it("highlights 'A' bucket if user is in 'A' group", function () {

--- a/src/events/ab_test_settings.js
+++ b/src/events/ab_test_settings.js
@@ -1,0 +1,26 @@
+(function initializeAbHeaders() {
+  var abTestBuckets = {};
+
+  function addAbHeaders(details) {
+    Object.keys(abTestBuckets).map(function (abTestName) {
+      details.requestHeaders.push({
+        name: "GOVUK-ABTest-" + abTestName,
+        value: abTestBuckets[abTestName]
+      });
+    });
+
+    return {requestHeaders: details.requestHeaders};
+  }
+
+  chrome.webRequest.onBeforeSendHeaders.addListener(
+    addAbHeaders,
+    {urls: ["*://*.gov.uk/*"]},
+    ["requestHeaders", "blocking"]
+  );
+
+  chrome.runtime.onMessage.addListener(function (request, sender) {
+    if (request.action == "set-ab-bucket") {
+      abTestBuckets[request.abTestName] = request.abTestBucket;
+    }
+  });
+}());

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -20,7 +20,9 @@
   },
   "permissions": [
     "http://*.gov.uk/*",
-    "https://*.gov.uk/*"
+    "https://*.gov.uk/*",
+    "webRequest",
+    "webRequestBlocking"
   ],
   "page_action": {
     "default_icon": {
@@ -31,6 +33,6 @@
     "default_popup": "popup.html"
   },
   "background": {
-    "scripts": ["events/icon.js"]
+    "scripts": ["events/icon.js", "events/ab_test_settings.js"]
   }
 }

--- a/src/popup.html
+++ b/src/popup.html
@@ -31,9 +31,9 @@
         <ul>
         {{#abTests}}
           <li>
-            <span class='ab-test-name'>{{name}}</span>
+            <span class='ab-test-name'>{{testName}}</span>
             {{#buckets}}
-              <span class='ab-test-bucket {{class}}'>{{name}}</span>
+              <span class='ab-test-bucket {{class}}' data-test-name='{{testName}}' data-bucket='{{bucketName}}'>{{bucketName}}</span>
             {{/buckets}}
           </li>
         {{/abTests}}

--- a/src/popup/ab_tests.js
+++ b/src/popup/ab_tests.js
@@ -8,10 +8,10 @@ Popup.findActiveAbTests = function(abTestBuckets) {
     var currentBucket = abTestBuckets[abTestName];
 
     return {
-      name: abTestName,
+      testName: abTestName,
       buckets: buckets.map(function (bucketName) {
         return {
-          name: bucketName,
+          bucketName: bucketName,
           class: currentBucket === bucketName ? "ab-bucket-selected" : ""
         };
       })

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -71,9 +71,10 @@ li a:hover {
 
 .ab-test-bucket {
   padding: 7px 9px 7px 9px;
+  cursor: pointer;
 }
 
-.ab-bucket-selected {
+.ab-bucket-selected, .ab-test-bucket:hover {
   color: #fff;
   background-color: #005ea5;
 }

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -40,6 +40,8 @@ var Popup = Popup || {};
         setupClicks();
       })
     }
+
+    setupAbToggles();
   }
 
   function setupClicks() {
@@ -74,6 +76,20 @@ var Popup = Popup || {};
   // https://stackoverflow.com/questions/20087368/how-to-detect-if-user-it-trying-to-open-a-link-in-a-new-tab
   function userOpensPageInNewWindow(e) {
     return e.ctrlKey || e.shiftKey || e.metaKey || (e.button && e.button == 1);
+  }
+
+  function setupAbToggles() {
+    $('.ab-test-bucket').on('click', function(e) {
+
+      chrome.runtime.sendMessage({
+        action: 'set-ab-bucket',
+        abTestName: $(this).data('testName'),
+        abTestBucket: $(this).data('bucket')
+      });
+
+      $(this).addClass('ab-bucket-selected');
+      $(this).siblings('.ab-test-bucket').removeClass('ab-bucket-selected');
+    });
   }
 
   // This is the view object. It takes a location and the name of the rendering


### PR DESCRIPTION
Make the A/B test buckets interactive, so that a user can select the version that they want to see. This works by appending a custom HTTP header to the request, which will only work against origin servers - it will be overridden by Varnish configuration if the request passes through the CDN. A future commit will add the same functionality using a cookie, which will work with the CDN.

Note that the selected A/B buckets are not persisted when the browser is closed.

https://trello.com/b/tYdZLGIe/navigation-team

**Same as #47**, but that was merged into another dev branch. This PR is against master.