### PR TITLE
Allow users to select an A/B bucket on Production

### DIFF
--- a/src/events/ab_test_settings.js
+++ b/src/events/ab_test_settings.js
@@ -21,6 +21,25 @@
   chrome.runtime.onMessage.addListener(function (request, sender) {
     if (request.action == "set-ab-bucket") {
       abTestBuckets[request.abTestName] = request.abTestBucket;
+
+      var cookieName = "ABTest-" + request.abTestName;
+
+      chrome.cookies.get({name: cookieName, url: request.url}, function (cookie) {
+        if (cookie) {
+          console.log(cookie);
+          cookie.value = request.abTestBucket;
+
+          var updatedCookie = {
+            name: cookieName,
+            value: request.abTestBucket,
+            url: request.url,
+            path: "/",
+            expirationDate: cookie.expirationDate
+          };
+
+          chrome.cookies.set(updatedCookie);
+        }
+      });
     }
   });
 }());

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -21,6 +21,7 @@
   "permissions": [
     "http://*.gov.uk/*",
     "https://*.gov.uk/*",
+    "cookies",
     "webRequest",
     "webRequestBlocking"
   ],

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -41,7 +41,7 @@ var Popup = Popup || {};
       })
     }
 
-    setupAbToggles();
+    setupAbToggles(location.href);
   }
 
   function setupClicks() {
@@ -78,13 +78,14 @@ var Popup = Popup || {};
     return e.ctrlKey || e.shiftKey || e.metaKey || (e.button && e.button == 1);
   }
 
-  function setupAbToggles() {
+  function setupAbToggles(url) {
     $('.ab-test-bucket').on('click', function(e) {
 
       chrome.runtime.sendMessage({
         action: 'set-ab-bucket',
         abTestName: $(this).data('testName'),
-        abTestBucket: $(this).data('bucket')
+        abTestBucket: $(this).data('bucket'),
+        url: url
       });
 
       $(this).addClass('ab-bucket-selected');


### PR DESCRIPTION
When the user selects a different A/B testing bucket, update the value of the relevant A/B cookie. This controls the user's A/B bucket on environments with a CDN, such as Production.

The custom header is still appended to the request, so that non-CDN environments still place the user in the correct bucket.

Trello: https://trello.com/c/jra1OClm/320-make-it-easy-to-test-experiments-in-non-prod-environments