### PR TITLE
Display correct A/B buckets when popup is reloaded

### DIFF
--- a/src/events/ab_test_settings.js
+++ b/src/events/ab_test_settings.js
@@ -1,6 +1,41 @@
 (function initializeAbHeaders() {
   var abTestBuckets = {};
 
+  function areAbTestsInitialized() {
+    return Object.getOwnPropertyNames(abTestBuckets).length > 0;
+  }
+
+  function initializeBuckets(initialBuckets, sendResponse) {
+    if (!areAbTestsInitialized()) {
+      Object.keys(initialBuckets).map(function (testName) {
+        abTestBuckets[testName] = initialBuckets[testName];
+      });
+    }
+
+    sendResponse(abTestBuckets);
+  }
+
+  function updateCookie(name, bucket, url) {
+    var cookieName = "ABTest-" + name;
+
+    chrome.cookies.get({name: cookieName, url: url}, function (cookie) {
+      if (cookie) {
+        console.log(cookie);
+        cookie.value = bucket;
+
+        var updatedCookie = {
+          name: cookieName,
+          value: bucket,
+          url: url,
+          path: "/",
+          expirationDate: cookie.expirationDate
+        };
+
+        chrome.cookies.set(updatedCookie);
+      }
+    });
+  }
+
   function addAbHeaders(details) {
     Object.keys(abTestBuckets).map(function (abTestName) {
       details.requestHeaders.push({
@@ -12,34 +47,18 @@
     return {requestHeaders: details.requestHeaders};
   }
 
+  chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
+    if (request.action === "set-ab-bucket") {
+      abTestBuckets[request.abTestName] = request.abTestBucket;
+      updateCookie(request.abTestName, request.abTestBucket, request.url);
+    } else if (request.action === "initialize-ab-buckets") {
+      initializeBuckets(request.abTestBuckets, sendResponse);
+    }
+  });
+
   chrome.webRequest.onBeforeSendHeaders.addListener(
     addAbHeaders,
     {urls: ["*://*.gov.uk/*"]},
     ["requestHeaders", "blocking"]
   );
-
-  chrome.runtime.onMessage.addListener(function (request, sender) {
-    if (request.action == "set-ab-bucket") {
-      abTestBuckets[request.abTestName] = request.abTestBucket;
-
-      var cookieName = "ABTest-" + request.abTestName;
-
-      chrome.cookies.get({name: cookieName, url: request.url}, function (cookie) {
-        if (cookie) {
-          console.log(cookie);
-          cookie.value = request.abTestBucket;
-
-          var updatedCookie = {
-            name: cookieName,
-            value: request.abTestBucket,
-            url: request.url,
-            path: "/",
-            expirationDate: cookie.expirationDate
-          };
-
-          chrome.cookies.set(updatedCookie);
-        }
-      });
-    }
-  });
 }());

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -15,12 +15,21 @@ var Popup = Popup || {};
   // render function.
   chrome.runtime.onMessage.addListener(function (request, _sender) {
     if (request.action == "populatePopup") {
-      renderPopup(
-        request.currentLocation,
-        request.renderingApplication,
-        request.abTestBuckets);
+      initializeBuckets(request.abTestBuckets, function (initializedBuckets) {
+        renderPopup(
+          request.currentLocation,
+          request.renderingApplication,
+          initializedBuckets);
+      });
     }
   });
+
+  function initializeBuckets(abTestBuckets, handleResponse) {
+    chrome.runtime.sendMessage({
+      action: 'initialize-ab-buckets',
+      abTestBuckets: abTestBuckets
+    }, handleResponse);
+  }
 
   // Render the popup.
   function renderPopup(location, renderingApplication, abTestBuckets) {


### PR DESCRIPTION
This fixes a bug in which the A/B bucket values were not being displayed correctly when the extension's popup was closed and re-opened. The values were always being loaded from the metadata on the page, even when the user had chosen different buckets.

The user's chosen buckets were being used correctly to set the headers and cookie - the problem was just in the display.

Note that this fix still doesn't persist A/B buckets between browser sessions in Dev/Integration/Staging. It just persists the buckets when the popup is closed and opened.

Trello: https://trello.com/c/jra1OClm/320-make-it-easy-to-test-experiments-in-non-prod-environments