### PR TITLE
Preserve cookie path when user chooses an A/B bucket

### DIFF
--- a/src/events/ab_test_settings.js
+++ b/src/events/ab_test_settings.js
@@ -20,14 +20,13 @@
 
     chrome.cookies.get({name: cookieName, url: url}, function (cookie) {
       if (cookie) {
-        console.log(cookie);
         cookie.value = bucket;
 
         var updatedCookie = {
           name: cookieName,
           value: bucket,
           url: url,
-          path: "/",
+          path: cookie.path,
           expirationDate: cookie.expirationDate
         };
 


### PR DESCRIPTION
This fixes a bug which caused the extension to create an extra cookie named `ABTest-Example`, rather than updating the value of the original cookie.

This is because the extension assumed that the cookie path is always the root path, which isn't always true. This is fixed by copying the cookie `path` attribute from the original cookie, which causes the browser to overwrite the original rather than duplicate it.

Trello: https://trello.com/c/jra1OClm/320-make-it-easy-to-test-experiments-in-non-prod-environments