### PR TITLE
Pick up new A/B tests without having to reload extension

### DIFF
--- a/src/events/ab_test_settings.js
+++ b/src/events/ab_test_settings.js
@@ -8,16 +8,14 @@
 (function() {
   var abTestBuckets = {};
 
-  function areAbTestsInitialized() {
-    return Object.getOwnPropertyNames(abTestBuckets).length > 0;
-  }
-
   function initializeBuckets(initialBuckets, callback) {
-    if (!areAbTestsInitialized()) {
-      Object.keys(initialBuckets).map(function (testName) {
+    Object.keys(initialBuckets).map(function (testName) {
+      // Add any A/B tests that are not already defined, but do not overwrite
+      // any that we are already tracking.
+      if (!abTestBuckets[testName]) {
         abTestBuckets[testName] = initialBuckets[testName];
-      });
-    }
+      }
+    });
 
     callback(abTestBuckets);
   }


### PR DESCRIPTION
Before, we were only initializing A/B tests the first time the popup detected any A/B meta tags. This means that if a new A/B was released, it would not appear in the popup until the user restarted Chrome or the extension.

This was also a problem in the more common situation where you you switch between environments with different A/B tests defined.

Trello: https://trello.com/c/jra1OClm/320-make-it-easy-to-test-experiments-in-non-prod-environments