### PR TITLE
Update A/B bucket parsing to match new meta tag format

### DIFF
--- a/src/fetch-page-data.js
+++ b/src/fetch-page-data.js
@@ -15,15 +15,15 @@ function getMetatag(name) {
 }
 
 function getAbTestBuckets() {
-  var abMetaTags = document.getElementsByTagName('meta');
+  var abMetaTags = document.querySelectorAll('meta[name="govuk:ab-test"]');
 
-  var abMetaTagPattern = /govuk:ab-test:([\w-]+):current-bucket/;
+  var metaTagPattern = /([\w-]+):([\w-]+)/;
+  var buckets = {};
 
-  return Object.keys(abMetaTags).filter(function (tagName) {
-    return tagName.match(abMetaTagPattern);
-  }).reduce(function (abTags, tagName) {
-    var abTestName = abMetaTagPattern.exec(tagName)[1];
-    abTags[abTestName] = abMetaTags[tagName].getAttribute('content');
-    return abTags;
-  }, {});
+  abMetaTags.forEach(function (metaTag) {
+    var testNameAndBucket = metaTagPattern.exec(metaTag.content);
+    buckets[testNameAndBucket[1]] = testNameAndBucket[2];
+  });
+
+  return buckets;
 }


### PR DESCRIPTION
The syntax of the A/B testing meta tag has been changed so that it fits the format expected by the Google Analytics code (alphagov/frontend#1110). This commit updates the tag parsing to extract the test name and current buckets from the new format.

Old format:
`<meta name="govuk:ab-test:Example:current-bucket" content="A">`

New format:
`<meta name="govuk:ab-test" content="Example:A">`

Trello:
https://trello.com/c/g9OyC7Pn/310-tell-google-analytics-about-a-b-tests

