### PR TITLE
Simplify message passing between popup and background script

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -17,16 +17,14 @@ var Popup = Popup || {};
     if (request.action == "populatePopup") {
       // When we're asked to populate the popup, we'll first send the current
       // buckets back to the main thread, which "persists" them.
-      chrome.runtime.sendMessage({
-        action: 'initialize-ab-buckets',
-        abTestBuckets: request.abTestBuckets
-      }, function (initializedBuckets) {
-        renderPopup(
-          request.currentLocation,
-          request.renderingApplication,
-          initializedBuckets
-        );
-      });
+      var abTestSettings = chrome.extension.getBackgroundPage().abTestSettings;
+      var abTestBuckets = abTestSettings.initialize(request.abTestBuckets);
+
+      renderPopup(
+        request.currentLocation,
+        request.renderingApplication,
+        abTestBuckets
+      );
     }
   });
 
@@ -96,12 +94,11 @@ var Popup = Popup || {};
   function setupAbToggles(url) {
     $('.ab-test-bucket').on('click', function(e) {
 
-      chrome.runtime.sendMessage({
-        action: 'set-ab-bucket',
-        abTestName: $(this).data('testName'),
-        abTestBucket: $(this).data('bucket'),
-        url: url
-      });
+      var abTestSettings = chrome.extension.getBackgroundPage().abTestSettings;
+      abTestSettings.setBucket(
+        $(this).data('testName'),
+        $(this).data('bucket'),
+        url);
 
       $(this).addClass('ab-bucket-selected');
       $(this).siblings('.ab-test-bucket').removeClass('ab-bucket-selected');


### PR DESCRIPTION
Call background script which stores A/B test settings from the popup script directly, rather than sending and listening for events. Events are only necessary when communicating between content and background scripts.

This is in preparation for storing environment-specific A/B test settings: using function calls rather than `chrome.runtime.onMessage` will make this easier to unit test, as well as being conceptually simpler.

https://trello.com/c/jra1OClm/320-make-it-easy-to-test-experiments-in-non-prod-environments