### PR TITLE
Make A/B test settings environment-specific

### DIFF
--- a/spec/javascripts/events/ab_bucket_store_spec.js
+++ b/spec/javascripts/events/ab_bucket_store_spec.js
@@ -1,0 +1,68 @@
+describe("abBucketStore", function () {
+  it("is initialized empty if no bucket are provided", function () {
+    var store = abBucketStore.createStore();
+
+    expect(store.getAll()).toEqual({});
+  });
+
+  describe("addAbTests", function () {
+    it("does nothing if no tests are added to an already-empty store", function () {
+      var store = abBucketStore.createStore();
+      store.addAbTests({});
+
+      expect(store.getAll()).toEqual({});
+    });
+
+    it("adds tests to empty store", function () {
+      var store = abBucketStore.createStore();
+      store.addAbTests({
+        testName1: "bucket1",
+        testName2: "bucket2"
+      });
+
+      expect(store.getAll()).toEqual({
+        testName1: "bucket1",
+        testName2: "bucket2"
+      });
+    });
+
+    it("appends new tests", function () {
+      var store = abBucketStore.createStore();
+      store.addAbTests({
+        originalTest1: "originalBucket1",
+        originalTest2: "originalBucket2"
+      });
+
+      store.addAbTests({
+        originalTest1: "updatedBucket1",
+        newTest1: "newBucket1",
+        originalTest2: "updatedBucket2",
+        newTest2: "newBucket2"
+      });
+
+      expect(store.getAll()).toEqual({
+        originalTest1: "originalBucket1",
+        originalTest2: "originalBucket2",
+        newTest1: "newBucket1",
+        newTest2: "newBucket2"
+      });
+    });
+  });
+
+  describe("setBucket", function() {
+    it("updates value of existing bucket", function () {
+      var store = abBucketStore.createStore();
+      store.addAbTests({
+        testName1: "originalBucket1",
+        testName2: "originalBucket2"
+      });
+
+      store.setBucket("testName1", "updatedBucket");
+
+      expect(store.getAll()).toEqual({
+        testName1: "updatedBucket",
+        testName2: "originalBucket2"
+      });
+    });
+  });
+});

--- a/spec/javascripts/events/ab_bucket_store_spec.js
+++ b/spec/javascripts/events/ab_bucket_store_spec.js
@@ -1,5 +1,5 @@
 describe("abBucketStore", function () {
-  it("is initialized empty if no bucket are provided", function () {
+  it("is initialized empty", function () {
     var store = abBucketStore.createStore();
 
     expect(store.getAll()).toEqual({});
@@ -8,9 +8,9 @@ describe("abBucketStore", function () {
   describe("addAbTests", function () {
     it("does nothing if no tests are added to an already-empty store", function () {
       var store = abBucketStore.createStore();
-      store.addAbTests({});
+      store.addAbTests({}, "example.com");
 
-      expect(store.getAll()).toEqual({});
+      expect(store.getAll("example.com")).toEqual({});
     });
 
     it("adds tests to empty store", function () {
@@ -18,9 +18,9 @@ describe("abBucketStore", function () {
       store.addAbTests({
         testName1: "bucket1",
         testName2: "bucket2"
-      });
+      }, "example.com");
 
-      expect(store.getAll()).toEqual({
+      expect(store.getAll("example.com")).toEqual({
         testName1: "bucket1",
         testName2: "bucket2"
       });
@@ -31,37 +31,84 @@ describe("abBucketStore", function () {
       store.addAbTests({
         originalTest1: "originalBucket1",
         originalTest2: "originalBucket2"
-      });
+      }, "example.com");
 
       store.addAbTests({
         originalTest1: "updatedBucket1",
         newTest1: "newBucket1",
         originalTest2: "updatedBucket2",
         newTest2: "newBucket2"
-      });
+      }, "example.com");
 
-      expect(store.getAll()).toEqual({
+      expect(store.getAll("example.com")).toEqual({
         originalTest1: "originalBucket1",
         originalTest2: "originalBucket2",
         newTest1: "newBucket1",
         newTest2: "newBucket2"
       });
     });
+
+    it("stores A/B tests by domain name", function () {
+      var store = abBucketStore.createStore();
+      store.addAbTests({
+        integrationAbTest: "bucketOnInt",
+      }, "www-origin.integration.publishing.service.gov.uk");
+      store.addAbTests({
+        productionAbTest: "bucketOnProd",
+      }, "www.gov.uk");
+
+      expect(store.getAll("www-origin.integration.publishing.service.gov.uk")).toEqual({
+        integrationAbTest: "bucketOnInt",
+      });
+      expect(store.getAll("www.gov.uk")).toEqual({
+        productionAbTest: "bucketOnProd",
+      });
+    });
   });
 
-  describe("setBucket", function() {
+  describe("getAll", function () {
+    it("returns no A/B tests if none have been stored for that domain", function () {
+      var store = abBucketStore.createStore();
+      store.addAbTests({
+        someAbTest: "someBucket",
+      }, "www.gov.uk");
+
+      expect(store.getAll("example.com")).toEqual({});
+    });
+  });
+
+  describe("setBucket", function () {
     it("updates value of existing bucket", function () {
       var store = abBucketStore.createStore();
       store.addAbTests({
         testName1: "originalBucket1",
         testName2: "originalBucket2"
-      });
+      }, "example.com");
 
-      store.setBucket("testName1", "updatedBucket");
+      store.setBucket("testName1", "updatedBucket", "example.com");
 
-      expect(store.getAll()).toEqual({
+      expect(store.getAll("example.com")).toEqual({
         testName1: "updatedBucket",
         testName2: "originalBucket2"
+      });
+    });
+
+    it("updates bucket with matching domain name", function () {
+      var store = abBucketStore.createStore();
+      store.addAbTests({
+        abTestName: "originalBucket",
+      }, "www-origin.integration.publishing.service.gov.uk");
+      store.addAbTests({
+        abTestName: "originalBucket",
+      }, "www.gov.uk");
+
+      store.setBucket("abTestName", "updatedBucket", "www.gov.uk");
+
+      expect(store.getAll("www-origin.integration.publishing.service.gov.uk")).toEqual({
+        abTestName: "originalBucket",
+      });
+      expect(store.getAll("www.gov.uk")).toEqual({
+        abTestName: "updatedBucket",
       });
     });
   });

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -1,4 +1,5 @@
 src_files:
+    - src/events/ab_bucket_store.js
     - src/popup/lib/jquery.min.js
     - src/popup/ab_tests.js
     - src/popup/content_links.js

--- a/src/events/ab_bucket_store.js
+++ b/src/events/ab_bucket_store.js
@@ -6,22 +6,24 @@ var abBucketStore = (function () {
   function createStore() {
     var abTestBuckets = {};
 
-    function addAbTests(initialBuckets) {
+    function addAbTests(initialBuckets, hostname) {
+      abTestBuckets[hostname] = abTestBuckets[hostname] || {};
+
       Object.keys(initialBuckets).map(function (testName) {
         // Add any A/B tests that are not already defined, but do not overwrite
         // any that we are already tracking.
-        if (!abTestBuckets[testName]) {
-          abTestBuckets[testName] = initialBuckets[testName];
+        if (!abTestBuckets[hostname][testName]) {
+          abTestBuckets[hostname][testName] = initialBuckets[testName];
         }
       });
     }
 
-    function getAll() {
-      return abTestBuckets;
+    function getAll(hostname) {
+      return abTestBuckets[hostname] || {};
     }
 
-    function setBucket(testName, bucket) {
-      abTestBuckets[testName] = bucket;
+    function setBucket(testName, bucket, hostname) {
+      abTestBuckets[hostname][testName] = bucket;
     }
 
     return {

--- a/src/events/ab_bucket_store.js
+++ b/src/events/ab_bucket_store.js
@@ -1,0 +1,37 @@
+// This script is executed in the background.
+//
+// It stores the environment-specific state of the user's A/B testing buckets in
+// memory, until the browser or the extension is next reloaded.
+var abBucketStore = (function () {
+  function createStore() {
+    var abTestBuckets = {};
+
+    function addAbTests(initialBuckets) {
+      Object.keys(initialBuckets).map(function (testName) {
+        // Add any A/B tests that are not already defined, but do not overwrite
+        // any that we are already tracking.
+        if (!abTestBuckets[testName]) {
+          abTestBuckets[testName] = initialBuckets[testName];
+        }
+      });
+    }
+
+    function getAll() {
+      return abTestBuckets;
+    }
+
+    function setBucket(testName, bucket) {
+      abTestBuckets[testName] = bucket;
+    }
+
+    return {
+      addAbTests: addAbTests,
+      getAll: getAll,
+      setBucket: setBucket
+    }
+  }
+
+  return {
+    createStore: createStore
+  }
+}());

--- a/src/events/ab_test_settings.js
+++ b/src/events/ab_test_settings.js
@@ -9,9 +9,11 @@ var abTestSettings = (function() {
 
   var abBucketStore = chrome.extension.getBackgroundPage().abBucketStore.createStore();
 
-  function initialize(initialBuckets) {
-    abBucketStore.addAbTests(initialBuckets);
-    return abBucketStore.getAll();
+  function initialize(initialBuckets, url) {
+    var hostname = extractHostname(url);
+
+    abBucketStore.addAbTests(initialBuckets, hostname);
+    return abBucketStore.getAll(hostname);
   }
 
   function updateCookie(name, bucket, url) {
@@ -35,12 +37,12 @@ var abTestSettings = (function() {
   }
 
   function setBucket(testName, bucketName, url) {
-    abBucketStore.setBucket(testName, bucketName);
+    abBucketStore.setBucket(testName, bucketName, extractHostname(url));
     updateCookie(testName, bucketName, url);
   }
 
   function addAbHeaders(details) {
-    var abTestBuckets = abBucketStore.getAll();
+    var abTestBuckets = abBucketStore.getAll(extractHostname(details.url));
 
     Object.keys(abTestBuckets).map(function (abTestName) {
       details.requestHeaders.push({
@@ -50,6 +52,10 @@ var abTestSettings = (function() {
     });
 
     return {requestHeaders: details.requestHeaders};
+  }
+
+  function extractHostname(url) {
+    return new URL(url).hostname;
   }
 
   chrome.webRequest.onBeforeSendHeaders.addListener(

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -34,6 +34,10 @@
     "default_popup": "popup.html"
   },
   "background": {
-    "scripts": ["events/icon.js", "events/ab_test_settings.js"]
+    "scripts": [
+      "events/icon.js",
+      "events/ab_bucket_store.js",
+      "events/ab_test_settings.js"
+    ]
   }
 }

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -18,7 +18,7 @@ var Popup = Popup || {};
       // When we're asked to populate the popup, we'll first send the current
       // buckets back to the main thread, which "persists" them.
       var abTestSettings = chrome.extension.getBackgroundPage().abTestSettings;
-      var abTestBuckets = abTestSettings.initialize(request.abTestBuckets);
+      var abTestBuckets = abTestSettings.initialize(request.abTestBuckets, request.currentLocation.href);
 
       renderPopup(
         request.currentLocation,


### PR DESCRIPTION
This fixes issues like this:
    
1. Visit an A/B test page on Integration.
2. Set the bucket to B. Integration has no CDN and no A/B cookies, this just sets the header that would be sent with the request.
3. Visit the A/B page in on Production.
4. If this happens to place you in the B bucket, everything is consistent, and the extension works as  expected. But if you are placed in the A bucket, your A/B cookie will say 'A' but the extension will  show 'B'.

https://trello.com/c/jra1OClm/320-make-it-easy-to-test-experiments-in-non-prod-environments

Marked as DO NOT MERGE because it depends on on #58. If that gets merged, I'll rebase and update the merge base for this PR.