### PR TITLE
Immediately refresh page when user chooses A/B bucket

### DIFF
--- a/src/events/ab_test_settings.js
+++ b/src/events/ab_test_settings.js
@@ -16,7 +16,7 @@ var abTestSettings = (function() {
     return abBucketStore.getAll(hostname);
   }
 
-  function updateCookie(name, bucket, url) {
+  function updateCookie(name, bucket, url, callback) {
     var cookieName = "ABTest-" + name;
 
     chrome.cookies.get({name: cookieName, url: url}, function (cookie) {
@@ -31,14 +31,16 @@ var abTestSettings = (function() {
           expirationDate: cookie.expirationDate
         };
 
-        chrome.cookies.set(updatedCookie);
+        chrome.cookies.set(updatedCookie, callback);
+      } else {
+        callback();
       }
     });
   }
 
-  function setBucket(testName, bucketName, url) {
+  function setBucket(testName, bucketName, url, callback) {
     abBucketStore.setBucket(testName, bucketName, extractHostname(url));
-    updateCookie(testName, bucketName, url);
+    updateCookie(testName, bucketName, url, callback);
   }
 
   function addAbHeaders(details) {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -93,15 +93,20 @@ var Popup = Popup || {};
 
   function setupAbToggles(url) {
     $('.ab-test-bucket').on('click', function(e) {
+      var $selectedBucket = $(this);
 
       var abTestSettings = chrome.extension.getBackgroundPage().abTestSettings;
       abTestSettings.setBucket(
-        $(this).data('testName'),
-        $(this).data('bucket'),
-        url);
+        $selectedBucket.data('testName'),
+        $selectedBucket.data('bucket'),
+        url,
+        function () {
+          $selectedBucket.addClass('ab-bucket-selected');
+          $selectedBucket.siblings('.ab-test-bucket').removeClass('ab-bucket-selected');
 
-      $(this).addClass('ab-bucket-selected');
-      $(this).siblings('.ab-test-bucket').removeClass('ab-bucket-selected');
+          chrome.tabs.reload(null, { bypassCache: true });
+        }
+      );
     });
   }
 


### PR DESCRIPTION
When the user selects a different A/B bucket, they almost certainly want to see that version of the page immediately. This saves them a click each time.

https://trello.com/c/jra1OClm/320-make-it-easy-to-test-experiments-in-non-prod-environments

Marked as DO NOT MERGE because it depends on on #58. If that gets merged, I'll rebase and update the merge base for this PR.