### PR TITLE
Add link to document type documentation

### DIFF
--- a/spec/javascripts/external_links_spec.js
+++ b/spec/javascripts/external_links_spec.js
@@ -79,6 +79,19 @@ describe("Popup.generateExternalLinks", function () {
     })
   })
 
+  it("correctly links to document types", function () {
+    var contentItem = {
+      document_type: 'announcement'
+    }
+
+    var links = Popup.generateExternalLinks(contentItem, PROD_ENV)
+
+    expect(links).toContain({
+      name: 'Document type: announcement',
+      url: 'https://docs.publishing.service.gov.uk/document-types/announcement.html'
+    })
+  })
+
   it("generates edit links for topics", function () {
     var contentItem = {
       content_id: '4d8568c4-67f2-48da-a578-5ac6f35b69b4',

--- a/src/popup/external_links.js
+++ b/src/popup/external_links.js
@@ -61,6 +61,11 @@ Popup.generateExternalLinks = function(contentItem, env) {
   })
 
   links.push({
+    name: 'Document type: ' + contentItem.document_type,
+    url: 'https://docs.publishing.service.gov.uk/document-types/' + contentItem.document_type + '.html'
+  })
+
+  links.push({
     name: 'Publishing API debug (SSH tunnel required)',
     url: env.protocol + '://publishing-api.' + env.serviceDomain + '/debug/' + contentItem.content_id
   })

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -32,7 +32,7 @@ body {
 
 li a {
   display: block;
-  padding: 9px 10px;
+  padding: 8px 10px;
   color: #000;
   text-decoration: none;
 }


### PR DESCRIPTION
The docs now contain pages with info on (almost) all document types on GOV.UK:

https://docs.publishing.service.gov.uk/document-types.html

<img width="1380" alt="screen shot 2017-01-31 at 17 18 02" src="https://cloud.githubusercontent.com/assets/233676/22476171/47442aa0-e7d9-11e6-9655-9ce8561e439e.png">

https://trello.com/c/EfrOXi9L/8-create-document-type-documentation