### PR TITLE
Remove business-support-finder

### DIFF
--- a/spec/javascripts/external_links_spec.js
+++ b/spec/javascripts/external_links_spec.js
@@ -16,14 +16,14 @@ describe("Popup.generateExternalLinks", function () {
 
   it("generates a Github link when the rendering app does not match the repository name", function () {
     var contentItem = {
-      rendering_app: 'businesssupportfinder'
+      rendering_app: 'smartanswers'
     }
 
     var links = Popup.generateExternalLinks(contentItem, PROD_ENV)
 
     expect(links).toContain({
-      name: 'Rendering app: businesssupportfinder',
-      url: 'https://docs.publishing.service.gov.uk/apps/business-support-finder.html'
+      name: 'Rendering app: smartanswers',
+      url: 'https://docs.publishing.service.gov.uk/apps/smart-answers.html'
     })
   })
 

--- a/src/popup/external_links.js
+++ b/src/popup/external_links.js
@@ -21,7 +21,6 @@ Popup.generateExternalLinks = function(contentItem, env) {
       smartanswers: 'smart-answers',
       designprinciples: 'design-principles',
       'whitehall-frontend': 'whitehall',
-      businesssupportfinder: 'business-support-finder',
       tariff: 'trade-tariff-frontend'
     };
 


### PR DESCRIPTION
This commit removes business-support-finder, which has been replaced with finder-frontend.

Trello: https://trello.com/c/9O34PdXb/547-remove-business-support-finder-application