### PR TITLE
Remove the Content API

### DIFF
--- a/spec/javascripts/content_links_spec.js
+++ b/spec/javascripts/content_links_spec.js
@@ -14,7 +14,6 @@ describe("PopupView.generateContentLinks", function () {
       'https://www.gov.uk/api/content/browse/disabilities',
       'https://www.gov.uk/api/search.json?filter_link=/browse/disabilities',
       'https://www.gov.uk/info/browse/disabilities',
-      'https://www.gov.uk/api/browse/disabilities.json',
       'https://draft-origin.publishing.service.gov.uk/browse/disabilities',
       'https://support.publishing.service.gov.uk/anonymous_feedback?path=/browse/disabilities',
       'http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk/browse/disabilities'
@@ -70,7 +69,6 @@ describe("PopupView.generateContentLinks", function () {
       'https://www.gov.uk/api/content/browse/disabilities',
       'https://www.gov.uk/api/search.json?filter_link=/browse/disabilities',
       'https://www.gov.uk/info/browse/disabilities',
-      'https://www.gov.uk/api/browse/disabilities.json',
       'https://draft-origin.publishing.service.gov.uk/browse/disabilities',
       'https://support.publishing.service.gov.uk/anonymous_feedback?path=/browse/disabilities',
       'http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk/browse/disabilities'
@@ -90,34 +88,6 @@ describe("PopupView.generateContentLinks", function () {
       'https://www.gov.uk/api/content/maternity-paternity-calculator'
     )
   })
-
-  it("generates the correct content api DVLA url", function () {
-    var links = Popup.generateContentLinks(
-      stubLocation("https://www.gov.uk/done/pay-dvla-fine"),
-      PROD_ENV,
-      "frontend"
-    )
-
-    var urls = pluck(links, 'url')
-
-    expect(urls).toContain(
-      "https://www.gov.uk/api/content/done/pay-dvla-fine"
-    )
-  });
-
-  it("generates the correct content api for help pages", function () {
-    var links = Popup.generateContentLinks(
-      stubLocation("https://www.gov.uk/help/cookies"),
-      PROD_ENV,
-      "frontend"
-    )
-
-    var urls = pluck(links, 'url')
-
-    expect(urls).toContain(
-      "https://www.gov.uk/api/content/help/cookies"
-    )
-  });
 
   it("generates correct mainstream content store URL", function () {
     var links = Popup.generateContentLinks(

--- a/spec/javascripts/extract_path_spec.js
+++ b/spec/javascripts/extract_path_spec.js
@@ -41,18 +41,6 @@ describe("Popup.extractPath", function () {
     expect(path).toBe("/browse/disabilities")
   })
 
-  it("returns the path for content-api pages", function () {
-    var path = Popup.extractPath(stubLocation("https://www.gov.uk/api/browse/disabilities.json"))
-
-    expect(path).toBe("/browse/disabilities")
-  })
-
-  it("returns the path for content-api pages", function () {
-    var path = Popup.extractPath(stubLocation("https://www.gov.uk/api/foo.json"))
-
-    expect(path).toBe("/foo")
-  })
-
   it("returns the path for search pages", function () {
     var path = Popup.extractPath(stubLocation("https://www.gov.uk/api/search.json?filter_link=/browse/disabilities"))
 

--- a/src/popup/content_links.js
+++ b/src/popup/content_links.js
@@ -37,7 +37,6 @@ Popup.generateContentLinks = function(location, currentEnvironment, renderingApp
     links.push({ name: "Content item (JSON)", url: contentStoreUrl })
     links.push({ name: "Search data (JSON)", url: originHost + "/api/search.json?filter_link=" + path })
     links.push({ name: "Info page", url: originHost + "/info" + path })
-    links.push({ name: "Content API (JSON, deprecated)", url: originHost + "/api" + path + ".json" })
     links.push({ name: "Draft (may not always work)", url: currentEnvironment.protocol + '://draft-origin.' + currentEnvironment.serviceDomain + path })
     links.push({ name: "User feedback", url: currentEnvironment.protocol + '://support.' + currentEnvironment.serviceDomain + '/anonymous_feedback?path=' + path })
   }


### PR DESCRIPTION
The [`content_api`](https://github.com/alphagov/govuk_content_api) has
been retired, and all content has been migrated to the
[`content_store`](https://github.com/alphagov/content-store).

Therefore, we can remove all references to the Content API, and rely
solely on the Content Store.

### Trello

https://trello.com/c/TsUsUwD7/153-remove-documentation-on-content-api