### PR TITLE
Read variant names from metatag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'rake'
-gem 'jasmine', '~> 2.4'
+gem 'jasmine', '~> 2.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,22 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    jasmine (2.4.0)
-      jasmine-core (~> 2.4)
+    jasmine (2.6.0)
+      jasmine-core (>= 2.6.0, < 3.0.0)
       phantomjs
       rack (>= 1.2.1)
       rake
-    jasmine-core (2.4.1)
+    jasmine-core (2.6.3)
     phantomjs (2.1.1.0)
-    rack (1.6.4)
-    rake (10.5.0)
+    rack (2.0.3)
+    rake (12.0.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  jasmine (~> 2.4)
+  jasmine (~> 2.6)
   rake
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/spec/javascripts/ab_tests_spec.js
+++ b/spec/javascripts/ab_tests_spec.js
@@ -7,9 +7,18 @@ describe("Popup.findActiveAbTests", function () {
 
   it("finds all A/B tests", function () {
     var abTests = Popup.findActiveAbTests({
-      "first-AB-test-name": "some-value",
-      "second-AB-test-name": "other-value",
-      "third-AB-test-name": "yet-another-value",
+      "first-AB-test-name": {
+        currentBucket: "some-value",
+        allowedBuckets: ["some-value", "B"]
+      },
+      "second-AB-test-name": {
+        currentBucket: "other-value",
+        allowedBuckets: ["other-value", "B"]
+      },
+      "third-AB-test-name": {
+        currentBucket: "yet-another-value",
+        allowedBuckets: ["A", "yet-another-value"]
+      }
     });
 
     expect(abTests.length).toEqual(3);
@@ -20,18 +29,27 @@ describe("Popup.findActiveAbTests", function () {
 
   it("returns A and B buckets", function () {
     var abTests = Popup.findActiveAbTests({
-      "some-AB-test-name": "some-value"
+      "some-AB-test-name": {
+        currentBucket: "A",
+        allowedBuckets: ["A", "B"]
+      }
     });
 
     expect(abTests[0].buckets.length).toEqual(2);
     expect(abTests[0].buckets[0].bucketName).toEqual("A");
     expect(abTests[0].buckets[1].bucketName).toEqual("B");
-  });
+  })
 
   it("highlights 'A' bucket if user is in 'A' group", function () {
     var abTests = Popup.findActiveAbTests({
-      "some-AB-test-name": "B",
-      "other-AB-test-name": "A"
+      "some-AB-test-name": {
+        currentBucket: "B",
+        allowedBuckets: ["A", "B"]
+      },
+      "other-AB-test-name": {
+        currentBucket: "A",
+        allowedBuckets: ["A", "B"]
+      }
     });
 
     expect(abTests[0].buckets[0].class).toEqual("");
@@ -43,7 +61,10 @@ describe("Popup.findActiveAbTests", function () {
 
   it("doesn't highlight any buckets if variant is unknown", function () {
     var abTests = Popup.findActiveAbTests({
-      "some-AB-test-name": "some-unknown-bucket"
+      "some-AB-test-name": {
+        currentBucket: "Unknown",
+        allowedBuckets: ["A", "B"]
+      }
     });
 
     expect(abTests[0].buckets[0].class).toEqual("");

--- a/spec/javascripts/events/ab_bucket_store_spec.js
+++ b/spec/javascripts/events/ab_bucket_store_spec.js
@@ -81,34 +81,58 @@ describe("abBucketStore", function () {
     it("updates value of existing bucket", function () {
       var store = abBucketStore.createStore();
       store.addAbTests({
-        testName1: "originalBucket1",
-        testName2: "originalBucket2"
+        testName1: {
+          currentBucket: "originalBucket1",
+          allowedBuckets: ["originalBucket1", "updatedBucket"]
+        },
+        testName2: {
+          currentBucket: "originalBucket2",
+          allowedBuckets: ["originalBucket1", "originalBucket2"]
+        }
       }, "example.com");
 
       store.setBucket("testName1", "updatedBucket", "example.com");
 
       expect(store.getAll("example.com")).toEqual({
-        testName1: "updatedBucket",
-        testName2: "originalBucket2"
+        testName1: {
+          currentBucket: "updatedBucket",
+          allowedBuckets: ["originalBucket1", "updatedBucket"]
+        },
+        testName2: {
+          currentBucket: "originalBucket2",
+          allowedBuckets: ["originalBucket1", "originalBucket2"]
+        }
       });
     });
 
     it("updates bucket with matching domain name", function () {
       var store = abBucketStore.createStore();
       store.addAbTests({
-        abTestName: "originalBucket",
+        abTestName: {
+          currentBucket: "originalBucket",
+          allowedBuckets: ["originalBucket", "updatedBucket"]
+        }
       }, "www-origin.integration.publishing.service.gov.uk");
       store.addAbTests({
-        abTestName: "originalBucket",
+        abTestName: {
+          currentBucket: "originalBucket",
+          allowedBuckets: ["originalBucket", "updatedBucket"]
+        }
       }, "www.gov.uk");
 
       store.setBucket("abTestName", "updatedBucket", "www.gov.uk");
 
       expect(store.getAll("www-origin.integration.publishing.service.gov.uk")).toEqual({
-        abTestName: "originalBucket",
+        abTestName: {
+          currentBucket: "originalBucket",
+          allowedBuckets: ["originalBucket", "updatedBucket"]
+        }
       });
       expect(store.getAll("www.gov.uk")).toEqual({
-        abTestName: "updatedBucket",
+        abTestName: {
+          currentBucket: "updatedBucket",
+          allowedBuckets: ["originalBucket", "updatedBucket"]
+        }
       });
     });
   });

--- a/src/events/ab_bucket_store.js
+++ b/src/events/ab_bucket_store.js
@@ -23,7 +23,9 @@ var abBucketStore = (function () {
     }
 
     function setBucket(testName, bucket, hostname) {
-      abTestBuckets[hostname][testName] = bucket;
+      abTest = abTestBuckets[hostname][testName];
+      abTest.currentBucket = bucket;
+      abTestBuckets[hostname][testName] = abTest;
     }
 
     return {

--- a/src/events/ab_test_settings.js
+++ b/src/events/ab_test_settings.js
@@ -49,7 +49,7 @@ var abTestSettings = (function() {
     Object.keys(abTestBuckets).map(function (abTestName) {
       details.requestHeaders.push({
         name: "GOVUK-ABTest-" + abTestName,
-        value: abTestBuckets[abTestName]
+        value: abTestBuckets[abTestName].currentBucket
       });
     });
 

--- a/src/fetch-page-data.js
+++ b/src/fetch-page-data.js
@@ -22,7 +22,15 @@ function getAbTestBuckets() {
 
   abMetaTags.forEach(function (metaTag) {
     var testNameAndBucket = metaTagPattern.exec(metaTag.content);
-    buckets[testNameAndBucket[1]] = testNameAndBucket[2];
+    var testName = testNameAndBucket[1];
+    var currentBucket = testNameAndBucket[2];
+    var allowedBuckets =
+      (metaTag.dataset.allowedVariants || "A,B").split(",");
+
+    buckets[testName] = {
+      currentBucket: currentBucket,
+      allowedBuckets: allowedBuckets
+    }
   });
 
   return buckets;

--- a/src/popup/ab_tests.js
+++ b/src/popup/ab_tests.js
@@ -1,15 +1,14 @@
 var Popup = Popup || {};
 
 Popup.findActiveAbTests = function(abTestBuckets) {
-  const buckets = ["A", "B"];
-
   return Object.keys(abTestBuckets).map(function (abTestName) {
 
-    var currentBucket = abTestBuckets[abTestName];
+    var currentBucket = abTestBuckets[abTestName].currentBucket;
+    var allowedBuckets = abTestBuckets[abTestName].allowedBuckets;
 
     return {
       testName: abTestName,
-      buckets: buckets.map(function (bucketName) {
+      buckets: allowedBuckets.map(function (bucketName) {
         return {
           bucketName: bucketName,
           class: currentBucket === bucketName ? "ab-bucket-selected" : ""


### PR DESCRIPTION
This PR allows the Chrome extension to show different bucket names than just A and B. Now that we are adding functionality to `govuk_ab_testing` to rename variants, we need to allow the extension to show those. In order to know what variants we can choose from in a given A/B test, we've added a new data attribute to the analytics metatag called `data-allowed-variants` which lists the valid values. If no data attribute exists (for backwards compatibility), we default to `A` and `B`.

Here are the dependencies:
- [ ] https://github.com/alphagov/govuk_ab_testing/pull/45

And the related PRs that need this change:
- [ ] https://github.com/alphagov/collections/pull/346
- [ ] https://github.com/alphagov/govuk-cdn-config/pull/54

Part of: https://trello.com/c/S5jp2jih/179-setup-technical-implementation-for-a-b-testing-the-blue-box

Here is how it looks in development:

![custom-variants](https://user-images.githubusercontent.com/416701/26973454-9ca84d60-4d0e-11e7-82d3-133469c4b505.gif)
