### PR TITLE
Handle multiple query parameters when extracting the path

### DIFF
--- a/spec/javascripts/extract_path_spec.js
+++ b/spec/javascripts/extract_path_spec.js
@@ -47,6 +47,12 @@ describe("Popup.extractPath", function () {
     expect(path).toBe("/browse/disabilities")
   })
 
+  it("returns the path for cache-busted search pages", function () {
+    var path = Popup.extractPath(stubLocation("https://www.gov.uk/api/search.json?filter_link=/browse/disabilities&c=some_cache_buster"))
+
+    expect(path).toBe("/browse/disabilities")
+  })
+
   it("returns the path for national archives pages", function () {
     var path = Popup.extractPath(stubLocation("http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk/some/page"))
 

--- a/src/popup/extract_path.js
+++ b/src/popup/extract_path.js
@@ -9,13 +9,13 @@ Popup.extractPath = function(location, renderingApplication) {
     extractedPath = location.pathname.replace('api/content/', '');
   }
   else if (location.href.match(/anonymous_feedback/)) {
-    extractedPath = location.href.split('path=')[1];
+    extractedPath = extractQueryParameter(location, 'path');
   }
   else if (location.href.match(/nationalarchives.gov.uk/)) {
     extractedPath = location.pathname.split('https://www.gov.uk')[1];
   }
   else if (location.href.match(/api\/search.json/)) {
-    extractedPath = location.href.split('filter_link=')[1];
+    extractedPath = extractQueryParameter(location, 'filter_link');
   }
   else if (location.href.match(/info/)) {
     extractedPath = location.pathname.replace('info/', '');
@@ -32,5 +32,9 @@ Popup.extractPath = function(location, renderingApplication) {
 
   if (extractedPath) {
     return extractedPath.replace('//', '/');
+  }
+
+  function extractQueryParameter(location, parameter_name) {
+    return location.href.split(parameter_name + '=')[1].split('&')[0];
   }
 }


### PR DESCRIPTION
This is useful when other parameters have been added such as a cache-busting parameter. Previously, the Chrome extension would fail to load when other parameters were present.