### PR TITLE
Move /visualise to /y/visualise

### DIFF
--- a/spec/javascripts/content_links_spec.js
+++ b/spec/javascripts/content_links_spec.js
@@ -86,7 +86,7 @@ describe("PopupView.generateContentLinks", function () {
 
     expect(urls).toContain(
       "https://www.gov.uk/smart-answer/y/question-1.txt",
-      "https://www.gov.uk/smart-answer/visualise"
+      "https://www.gov.uk/smart-answer/y/visualise"
     )
   })
 

--- a/spec/javascripts/extract_path_spec.js
+++ b/spec/javascripts/extract_path_spec.js
@@ -60,7 +60,7 @@ describe("Popup.extractPath", function () {
   })
 
   it("returns the path for the smart answers visualisation", function () {
-    var path = Popup.extractPath(stubLocation("https://www.gov.uk/maternity-paternity-calculator/visualise"))
+    var path = Popup.extractPath(stubLocation("https://www.gov.uk/maternity-paternity-calculator/y/visualise"))
 
     expect(path).toBe("/maternity-paternity-calculator")
   })

--- a/src/popup/content_links.js
+++ b/src/popup/content_links.js
@@ -38,7 +38,7 @@ Popup.generateContentLinks = function(location, currentEnvironment, renderingApp
       links.push({ name: "SmartAnswers: Display GovSpeak", url: currentUrl + ".txt"})
     }
 
-    links.push({ name: "SmartAnswers: Visualise", url: currentUrl.replace(/\/y.*$/, "") + "/visualise" })
+    links.push({ name: "SmartAnswers: Visualise", url: currentUrl.replace(/\/y.*$/, "") + "/y/visualise" })
   }
 
   return links.map(function (link) {

--- a/src/popup/extract_path.js
+++ b/src/popup/extract_path.js
@@ -24,7 +24,7 @@ Popup.extractPath = function(location, renderingApplication) {
     extractedPath = location.pathname.replace('api/', '').replace('.json', '');
   }
   else if (location.href.match(/visualise/)) {
-    extractedPath = location.pathname.replace('/visualise', '');
+    extractedPath = location.pathname.replace('/y/visualise', '');
   }
   else if (location.href.match(/www/) || location.href.match(/draft-origin/)) {
     extractedPath = location.pathname;


### PR DESCRIPTION
[Trello card](https://trello.com/c/7SgBCc64/696-3-fix-broken-visualise-link)

## Motivation 
Following the separation of the start page from the rest of a smart answer flow from [1], the /visualise path has been made redundant returning 404 as a result.

PR [2], moves the /visualise path under /y (i.e /y/visualise) for the visualise tool.

This pull request updates this chrome extension so content designers can easily gain access to the visualise tool.

[1] https://github.com/alphagov/smart-answers/pull/3126
[2] https://github.com/alphagov/smart-answers/pull/3166

## Expected changes

- User will be able to click on "SmartAnswers: Visualise":
   - See the visualise page for the smart answer in question
   - Will not get a page not found response