### PR TITLE
Add function to outline GOV.UK components on page

### DIFF
--- a/spec/javascripts/fixtures/app-c-back-to-top.html
+++ b/spec/javascripts/fixtures/app-c-back-to-top.html
@@ -1,0 +1,6 @@
+<a class="app-c-back-to-top dont-print" href="#contents">
+  <svg class="app-c-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
+    <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
+  </svg>
+  Contents
+</a>

--- a/spec/javascripts/fixtures/govuk-breadcrumbs.html
+++ b/spec/javascripts/fixtures/govuk-breadcrumbs.html
@@ -1,0 +1,11 @@
+<div class="govuk-breadcrumbs " data-module="track-click">
+  <ol>
+    <li class="">
+      <a data-track-category="breadcrumbClicked" data-track-action="1" data-track-label="/section" data-track-options="{&quot;dimension28&quot;:&quot;2&quot;,&quot;dimension29&quot;:&quot;Section&quot;}" class="" aria-current="false" href="/section">Section</a>
+    </li>
+
+    <li class="">
+      <a data-track-category="breadcrumbClicked" data-track-action="2" data-track-label="/section/sub-section" data-track-options="{&quot;dimension28&quot;:&quot;2&quot;,&quot;dimension29&quot;:&quot;Sub-section&quot;}" class="" aria-current="false" href="/section/sub-section">Sub-section</a>
+    </li>
+  </ol>
+</div>

--- a/spec/javascripts/fixtures/pub-c-button.html
+++ b/spec/javascripts/fixtures/pub-c-button.html
@@ -1,0 +1,3 @@
+<button class="pub-c-button">
+  Submit
+</button>

--- a/spec/javascripts/highlight_component_spec.js
+++ b/spec/javascripts/highlight_component_spec.js
@@ -1,0 +1,217 @@
+'use strict';
+describe("Toggling component highlighting", function () {
+
+  var $breadcrumbsEl;
+  var highlightComponent;
+
+  beforeEach(function () {
+    loadFixtures("govuk-breadcrumbs.html")
+
+    // Mock addListener function to call toggleState trigger when initialized
+    window.chrome = {
+      runtime: {
+        onMessage: {
+          addListener: function(callback) {
+            callback({ trigger: 'toggleState' })
+          }
+        },
+        sendMessage: function(){}
+      }
+    };
+
+    highlightComponent = new HighlightComponent;
+
+    $breadcrumbsEl = $("#jasmine-fixtures .govuk-breadcrumbs");
+  });
+
+  it("highlights govuk components", function () {
+    expect($breadcrumbsEl).toHaveClass("highlight-component");
+  });
+
+  it("exposes the component name as data attribute", function () {
+    expect($breadcrumbsEl.data("component-name")).toEqual("breadcrumbs");
+  });
+
+  it("exposes the app name as data attribute", function () {
+    expect($breadcrumbsEl.data("app-name")).toEqual("govuk-");
+  });
+
+  it("adds the ability to click through to the component's documentation", function () {
+    spyOn(window, "open").and.callThrough()
+    var clickEvent = spyOnEvent($breadcrumbsEl, "click");
+
+    $breadcrumbsEl.click();
+
+    expect(clickEvent).toHaveBeenTriggered();
+    expect(window.open).toHaveBeenCalledWith(
+      "https://govuk-static.herokuapp.com/component-guide/breadcrumbs"
+    )
+  });
+
+  it("removes the highlight when toggled off", function () {
+    highlightComponent.toggleState();
+
+    expect($breadcrumbsEl).not.toHaveClass("highlight-component");
+  });
+
+  it("removes the click functionality when toggled off", function () {
+    spyOn(window, "open").and.callThrough()
+    highlightComponent.toggleState();
+
+    var clickEvent = spyOnEvent($breadcrumbsEl, "click");
+
+    $breadcrumbsEl.click();
+
+    expect(clickEvent).toHaveBeenTriggered();
+    expect(window.open).not.toHaveBeenCalled();
+  });
+});
+
+describe("highlightComponent", function () {
+  beforeEach(function() {
+    window.chrome = {
+      runtime: {
+        onMessage: {
+          addListener: function(callback) { }
+        },
+        sendMessage: function(){}
+      }
+    };
+  })
+
+  describe("components", function () {
+    var $html;
+
+    beforeEach(function () {
+      loadFixtures(
+        "app-c-back-to-top.html",
+        "govuk-breadcrumbs.html",
+        "pub-c-button.html"
+      )
+
+      $html = $("#jasmine-fixtures");
+    });
+
+    it("builds an array of components", function () {
+      var highlightComponent = new HighlightComponent;
+
+      expect(highlightComponent.components).toEqual(
+        [
+          {
+            name: "back-to-top",
+            prefix: "app-c-",
+            element: $html.find(".app-c-back-to-top")[0],
+          },
+          {
+            name: "breadcrumbs",
+            prefix: "govuk-",
+            element: $html.find(".govuk-breadcrumbs")[0],
+          },
+          {
+            name: "button",
+            prefix: "pub-c-",
+            element: $html.find(".pub-c-button")[0],
+          },
+        ]
+      )
+    });
+  });
+
+  describe("toggleState", function () {
+    it("toggles the internal state", function () {
+
+      var highlightComponent = new HighlightComponent;
+
+      expect(highlightComponent.state).toEqual(false);
+
+      highlightComponent.toggleState();
+      expect(highlightComponent.state).toEqual(true);
+
+      highlightComponent.toggleState();
+      expect(highlightComponent.state).toEqual(false);
+    });
+
+    it("toggles the highlight-component class", function () {
+      loadFixtures("pub-c-button.html");
+
+      var highlightComponent = new HighlightComponent;
+
+      var $buttonEl = $("#jasmine-fixtures .pub-c-button");
+      expect($buttonEl).not.toHaveClass("highlight-component");
+
+      highlightComponent.toggleState();
+      expect($buttonEl).toHaveClass("highlight-component");
+
+      highlightComponent.toggleState();
+      expect($buttonEl).not.toHaveClass("highlight-component");
+    });
+  });
+});
+
+describe("Helpers.documentationUrl", function () {
+  it("creates the correct URL for 'app' components with substitution", function () {
+    setFixtures('<head><meta name="govuk:rendering-application" content="collections"></head>');
+    Helpers.substitutions =  {
+      'collections': 'another_host'
+    };
+    expect(
+      Helpers.documentationUrl({
+        prefix: "app-c",
+        name: "back-to-top"
+      })
+    ).toEqual(
+      "https://another_host.herokuapp.com/component-guide/back-to-top"
+    )
+  });
+
+  it("creates the correct URL for 'app' components without substitution", function () {
+    setFixtures('<head><meta name="govuk:rendering-application" content="rendering_app"></head>');
+    Helpers.substitutions =  {
+      'collections': 'another_host'
+    };
+    expect(
+      Helpers.documentationUrl({
+        prefix: "app-c",
+        name: "back-to-top"
+      })
+    ).toEqual(
+      "https://rendering_app.herokuapp.com/component-guide/back-to-top"
+    )
+  });
+
+  it("creates the correct URL for 'pub' components", function () {
+    expect(
+      Helpers.documentationUrl({
+        prefix: "pub-c",
+        name: "title"
+      })
+    ).toEqual(
+      "https://govuk-static.herokuapp.com/component-guide/title"
+    )
+  });
+
+  it("creates the correct URL for (deprecated) 'govuk' components", function () {
+    expect(
+      Helpers.documentationUrl({
+        prefix: "govuk",
+        name: "beta-label"
+      })
+    ).toEqual(
+      "https://govuk-static.herokuapp.com/component-guide/beta_label"
+    )
+  });
+
+  // Currently there are no components that are using the newer govuk-c prefix
+  // but we have assumed that it will follow the same component-name and
+  // component_url mismatch (dashes & underscores) that exists in govuk-static
+  it("creates the correct URL for 'govuk' components", function () {
+    expect(
+      Helpers.documentationUrl({
+        prefix: "govuk-c",
+        name: "component-name"
+      })
+    ).toEqual(
+      "https://govuk-static.herokuapp.com/component-guide/component_name"
+    )
+  });
+});

--- a/spec/javascripts/support/jasmine-jquery.js
+++ b/spec/javascripts/support/jasmine-jquery.js
@@ -1,0 +1,841 @@
+/*!
+Jasmine-jQuery: a set of jQuery helpers for Jasmine tests.
+
+Version 2.1.1
+
+https://github.com/velesin/jasmine-jquery
+
+Copyright (c) 2010-2014 Wojciech Zawistowski, Travis Jeffery
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+(function (root, factory) {
+  if (typeof module !== 'undefined' && module.exports && typeof exports !== 'undefined') {
+    factory(root, root.jasmine, require('jquery'));
+  } else {
+    factory(root, root.jasmine, root.jQuery);
+  }
+}((function() {return this; })(), function (window, jasmine, $) { "use strict";
+
+  jasmine.spiedEventsKey = function (selector, eventName) {
+    return [$(selector).selector, eventName].toString()
+  }
+
+  jasmine.getFixtures = function () {
+    return jasmine.currentFixtures_ = jasmine.currentFixtures_ || new jasmine.Fixtures()
+  }
+
+  jasmine.getStyleFixtures = function () {
+    return jasmine.currentStyleFixtures_ = jasmine.currentStyleFixtures_ || new jasmine.StyleFixtures()
+  }
+
+  jasmine.Fixtures = function () {
+    this.containerId = 'jasmine-fixtures'
+    this.fixturesCache_ = {}
+    this.fixturesPath = 'spec/javascripts/fixtures'
+  }
+
+  jasmine.Fixtures.prototype.set = function (html) {
+    this.cleanUp()
+    return this.createContainer_(html)
+  }
+
+  jasmine.Fixtures.prototype.appendSet= function (html) {
+    this.addToContainer_(html)
+  }
+
+  jasmine.Fixtures.prototype.preload = function () {
+    this.read.apply(this, arguments)
+  }
+
+  jasmine.Fixtures.prototype.load = function () {
+    this.cleanUp()
+    this.createContainer_(this.read.apply(this, arguments))
+  }
+
+  jasmine.Fixtures.prototype.appendLoad = function () {
+    this.addToContainer_(this.read.apply(this, arguments))
+  }
+
+  jasmine.Fixtures.prototype.read = function () {
+    var htmlChunks = []
+      , fixtureUrls = arguments
+
+    for(var urlCount = fixtureUrls.length, urlIndex = 0; urlIndex < urlCount; urlIndex++) {
+      htmlChunks.push(this.getFixtureHtml_(fixtureUrls[urlIndex]))
+    }
+
+    return htmlChunks.join('')
+  }
+
+  jasmine.Fixtures.prototype.clearCache = function () {
+    this.fixturesCache_ = {}
+  }
+
+  jasmine.Fixtures.prototype.cleanUp = function () {
+    $('#' + this.containerId).remove()
+  }
+
+  jasmine.Fixtures.prototype.sandbox = function (attributes) {
+    var attributesToSet = attributes || {}
+    return $('<div id="sandbox" />').attr(attributesToSet)
+  }
+
+  jasmine.Fixtures.prototype.createContainer_ = function (html) {
+    var container = $('<div>')
+    .attr('id', this.containerId)
+    .html(html)
+
+    $(document.body).append(container)
+    return container
+  }
+
+  jasmine.Fixtures.prototype.addToContainer_ = function (html){
+    var container = $(document.body).find('#'+this.containerId).append(html)
+
+    if (!container.length) {
+      this.createContainer_(html)
+    }
+  }
+
+  jasmine.Fixtures.prototype.getFixtureHtml_ = function (url) {
+    if (typeof this.fixturesCache_[url] === 'undefined') {
+      this.loadFixtureIntoCache_(url)
+    }
+    return this.fixturesCache_[url]
+  }
+
+  jasmine.Fixtures.prototype.loadFixtureIntoCache_ = function (relativeUrl) {
+    var self = this
+      , url = this.makeFixtureUrl_(relativeUrl)
+      , htmlText = ''
+      , request = $.ajax({
+        async: false, // must be synchronous to guarantee that no tests are run before fixture is loaded
+        cache: false,
+        url: url,
+        dataType: 'html',
+        success: function (data, status, $xhr) {
+          htmlText = $xhr.responseText
+        }
+      }).fail(function ($xhr, status, err) {
+          throw new Error('Fixture could not be loaded: ' + url + ' (status: ' + status + ', message: ' + err.message + ')')
+      })
+
+      var scripts = $($.parseHTML(htmlText, true)).find('script[src]') || [];
+
+      scripts.each(function(){
+        $.ajax({
+            async: false, // must be synchronous to guarantee that no tests are run before fixture is loaded
+            cache: false,
+            dataType: 'script',
+            url: $(this).attr('src'),
+            success: function (data, status, $xhr) {
+                htmlText += '<script>' + $xhr.responseText + '</script>'
+            },
+            error: function ($xhr, status, err) {
+                throw new Error('Script could not be loaded: ' + url + ' (status: ' + status + ', message: ' + err.message + ')')
+            }
+        });
+      })
+
+      self.fixturesCache_[relativeUrl] = htmlText;
+  }
+
+  jasmine.Fixtures.prototype.makeFixtureUrl_ = function (relativeUrl){
+    return this.fixturesPath.match('/$') ? this.fixturesPath + relativeUrl : this.fixturesPath + '/' + relativeUrl
+  }
+
+  jasmine.Fixtures.prototype.proxyCallTo_ = function (methodName, passedArguments) {
+    return this[methodName].apply(this, passedArguments)
+  }
+
+
+  jasmine.StyleFixtures = function () {
+    this.fixturesCache_ = {}
+    this.fixturesNodes_ = []
+    this.fixturesPath = 'spec/javascripts/fixtures'
+  }
+
+  jasmine.StyleFixtures.prototype.set = function (css) {
+    this.cleanUp()
+    this.createStyle_(css)
+  }
+
+  jasmine.StyleFixtures.prototype.appendSet = function (css) {
+    this.createStyle_(css)
+  }
+
+  jasmine.StyleFixtures.prototype.preload = function () {
+    this.read_.apply(this, arguments)
+  }
+
+  jasmine.StyleFixtures.prototype.load = function () {
+    this.cleanUp()
+    this.createStyle_(this.read_.apply(this, arguments))
+  }
+
+  jasmine.StyleFixtures.prototype.appendLoad = function () {
+    this.createStyle_(this.read_.apply(this, arguments))
+  }
+
+  jasmine.StyleFixtures.prototype.cleanUp = function () {
+    while(this.fixturesNodes_.length) {
+      this.fixturesNodes_.pop().remove()
+    }
+  }
+
+  jasmine.StyleFixtures.prototype.createStyle_ = function (html) {
+    var styleText = $('<div></div>').html(html).text()
+      , style = $('<style>' + styleText + '</style>')
+
+    this.fixturesNodes_.push(style)
+    $('head').append(style)
+  }
+
+  jasmine.StyleFixtures.prototype.clearCache = jasmine.Fixtures.prototype.clearCache
+  jasmine.StyleFixtures.prototype.read_ = jasmine.Fixtures.prototype.read
+  jasmine.StyleFixtures.prototype.getFixtureHtml_ = jasmine.Fixtures.prototype.getFixtureHtml_
+  jasmine.StyleFixtures.prototype.loadFixtureIntoCache_ = jasmine.Fixtures.prototype.loadFixtureIntoCache_
+  jasmine.StyleFixtures.prototype.makeFixtureUrl_ = jasmine.Fixtures.prototype.makeFixtureUrl_
+  jasmine.StyleFixtures.prototype.proxyCallTo_ = jasmine.Fixtures.prototype.proxyCallTo_
+
+  jasmine.getJSONFixtures = function () {
+    return jasmine.currentJSONFixtures_ = jasmine.currentJSONFixtures_ || new jasmine.JSONFixtures()
+  }
+
+  jasmine.JSONFixtures = function () {
+    this.fixturesCache_ = {}
+    this.fixturesPath = 'spec/javascripts/fixtures/json'
+  }
+
+  jasmine.JSONFixtures.prototype.load = function () {
+    this.read.apply(this, arguments)
+    return this.fixturesCache_
+  }
+
+  jasmine.JSONFixtures.prototype.read = function () {
+    var fixtureUrls = arguments
+
+    for(var urlCount = fixtureUrls.length, urlIndex = 0; urlIndex < urlCount; urlIndex++) {
+      this.getFixtureData_(fixtureUrls[urlIndex])
+    }
+
+    return this.fixturesCache_
+  }
+
+  jasmine.JSONFixtures.prototype.clearCache = function () {
+    this.fixturesCache_ = {}
+  }
+
+  jasmine.JSONFixtures.prototype.getFixtureData_ = function (url) {
+    if (!this.fixturesCache_[url]) this.loadFixtureIntoCache_(url)
+    return this.fixturesCache_[url]
+  }
+
+  jasmine.JSONFixtures.prototype.loadFixtureIntoCache_ = function (relativeUrl) {
+    var self = this
+      , url = this.fixturesPath.match('/$') ? this.fixturesPath + relativeUrl : this.fixturesPath + '/' + relativeUrl
+
+    $.ajax({
+      async: false, // must be synchronous to guarantee that no tests are run before fixture is loaded
+      cache: false,
+      dataType: 'json',
+      url: url,
+      success: function (data) {
+        self.fixturesCache_[relativeUrl] = data
+      },
+      error: function ($xhr, status, err) {
+        throw new Error('JSONFixture could not be loaded: ' + url + ' (status: ' + status + ', message: ' + err.message + ')')
+      }
+    })
+  }
+
+  jasmine.JSONFixtures.prototype.proxyCallTo_ = function (methodName, passedArguments) {
+    return this[methodName].apply(this, passedArguments)
+  }
+
+  jasmine.jQuery = function () {}
+
+  jasmine.jQuery.browserTagCaseIndependentHtml = function (html) {
+    return $('<div/>').append(html).html()
+  }
+
+  jasmine.jQuery.elementToString = function (element) {
+    return $(element).map(function () { return this.outerHTML; }).toArray().join(', ')
+  }
+
+  var data = {
+      spiedEvents: {}
+    , handlers:    []
+  }
+
+  jasmine.jQuery.events = {
+    spyOn: function (selector, eventName) {
+      var handler = function (e) {
+        var calls = (typeof data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] !== 'undefined') ? data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].calls : 0
+        data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] = {
+          args: jasmine.util.argsToArray(arguments),
+          calls: ++calls
+        }
+      }
+
+      $(selector).on(eventName, handler)
+      data.handlers.push(handler)
+
+      return {
+        selector: selector,
+        eventName: eventName,
+        handler: handler,
+        reset: function (){
+          delete data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
+        },
+        calls: {
+          count: function () {
+              return data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] ?
+                data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].calls : 0;
+          },
+          any: function () {
+              return data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] ?
+                !!data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].calls : false;
+          }
+        }
+      }
+    },
+
+    args: function (selector, eventName) {
+      var actualArgs = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].args
+
+      if (!actualArgs) {
+        throw "There is no spy for " + eventName + " on " + selector.toString() + ". Make sure to create a spy using spyOnEvent."
+      }
+
+      return actualArgs
+    },
+
+    wasTriggered: function (selector, eventName) {
+      return !!(data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)])
+    },
+
+    wasTriggeredWith: function (selector, eventName, expectedArgs, util, customEqualityTesters) {
+      var actualArgs = jasmine.jQuery.events.args(selector, eventName).slice(1)
+
+      if (Object.prototype.toString.call(expectedArgs) !== '[object Array]')
+        actualArgs = actualArgs[0]
+
+      return util.equals(actualArgs, expectedArgs, customEqualityTesters)
+    },
+
+    wasPrevented: function (selector, eventName) {
+      var spiedEvent = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
+        , args = (jasmine.util.isUndefined(spiedEvent)) ? {} : spiedEvent.args
+        , e = args ? args[0] : undefined
+
+      return e && e.isDefaultPrevented()
+    },
+
+    wasStopped: function (selector, eventName) {
+      var spiedEvent = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
+        , args = (jasmine.util.isUndefined(spiedEvent)) ? {} : spiedEvent.args
+        , e = args ? args[0] : undefined
+
+      return e && e.isPropagationStopped()
+    },
+
+    cleanUp: function () {
+      data.spiedEvents = {}
+      data.handlers    = []
+    }
+  }
+
+  var hasProperty = function (actualValue, expectedValue) {
+    if (expectedValue === undefined)
+      return actualValue !== undefined
+
+    return actualValue === expectedValue
+  }
+
+  beforeEach(function () {
+    jasmine.addMatchers({
+      toHaveClass: function () {
+        return {
+          compare: function (actual, className) {
+            return { pass: $(actual).hasClass(className) }
+          }
+        }
+      },
+
+      toHaveCss: function () {
+        return {
+          compare: function (actual, css) {
+            var stripCharsRegex = /[\s;\"\']/g
+            for (var prop in css) {
+              var value = css[prop]
+              // see issue #147 on gh
+              ;if ((value === 'auto') && ($(actual).get(0).style[prop] === 'auto')) continue
+              var actualStripped = $(actual).css(prop).replace(stripCharsRegex, '')
+              var valueStripped = value.replace(stripCharsRegex, '')
+              if (actualStripped !== valueStripped) return { pass: false }
+            }
+            return { pass: true }
+          }
+        }
+      },
+
+      toBeVisible: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).is(':visible') }
+          }
+        }
+      },
+
+      toBeHidden: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).is(':hidden') }
+          }
+        }
+      },
+
+      toBeSelected: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).is(':selected') }
+          }
+        }
+      },
+
+      toBeChecked: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).is(':checked') }
+          }
+        }
+      },
+
+      toBeEmpty: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).is(':empty') }
+          }
+        }
+      },
+
+      toBeInDOM: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $.contains(document.documentElement, $(actual)[0]) }
+          }
+        }
+      },
+
+      toExist: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).length }
+          }
+        }
+      },
+
+      toHaveLength: function () {
+        return {
+          compare: function (actual, length) {
+            return { pass: $(actual).length === length }
+          }
+        }
+      },
+
+      toHaveAttr: function () {
+        return {
+          compare: function (actual, attributeName, expectedAttributeValue) {
+            return { pass: hasProperty($(actual).attr(attributeName), expectedAttributeValue) }
+          }
+        }
+      },
+
+      toHaveProp: function () {
+        return {
+          compare: function (actual, propertyName, expectedPropertyValue) {
+            return { pass: hasProperty($(actual).prop(propertyName), expectedPropertyValue) }
+          }
+        }
+      },
+
+      toHaveId: function () {
+        return {
+          compare: function (actual, id) {
+            return { pass: $(actual).attr('id') == id }
+          }
+        }
+      },
+
+      toHaveHtml: function () {
+        return {
+          compare: function (actual, html) {
+            return { pass: $(actual).html() == jasmine.jQuery.browserTagCaseIndependentHtml(html) }
+          }
+        }
+      },
+
+      toContainHtml: function () {
+        return {
+          compare: function (actual, html) {
+            var actualHtml = $(actual).html()
+              , expectedHtml = jasmine.jQuery.browserTagCaseIndependentHtml(html)
+
+            return { pass: (actualHtml.indexOf(expectedHtml) >= 0) }
+          }
+        }
+      },
+
+      toHaveText: function () {
+        return {
+          compare: function (actual, text) {
+            var actualText = $(actual).text()
+            var trimmedText = $.trim(actualText)
+
+            if (text && $.isFunction(text.test)) {
+              return { pass: text.test(actualText) || text.test(trimmedText) }
+            } else {
+              return { pass: (actualText == text || trimmedText == text) }
+            }
+          }
+        }
+      },
+
+      toContainText: function () {
+        return {
+          compare: function (actual, text) {
+            var trimmedText = $.trim($(actual).text())
+
+            if (text && $.isFunction(text.test)) {
+              return { pass: text.test(trimmedText) }
+            } else {
+              return { pass: trimmedText.indexOf(text) != -1 }
+            }
+          }
+        }
+      },
+
+      toHaveValue: function () {
+        return {
+          compare: function (actual, value) {
+            return { pass: $(actual).val() === value }
+          }
+        }
+      },
+
+      toHaveData: function () {
+        return {
+          compare: function (actual, key, expectedValue) {
+            return { pass: hasProperty($(actual).data(key), expectedValue) }
+          }
+        }
+      },
+
+      toContainElement: function () {
+        return {
+          compare: function (actual, selector) {
+            return { pass: $(actual).find(selector).length }
+          }
+        }
+      },
+
+      toBeMatchedBy: function () {
+        return {
+          compare: function (actual, selector) {
+            return { pass: $(actual).filter(selector).length }
+          }
+        }
+      },
+
+      toBeDisabled: function () {
+        return {
+          compare: function (actual, selector) {
+            return { pass: $(actual).is(':disabled') }
+          }
+        }
+      },
+
+      toBeFocused: function (selector) {
+        return {
+          compare: function (actual, selector) {
+            return { pass: $(actual)[0] === $(actual)[0].ownerDocument.activeElement }
+          }
+        }
+      },
+
+      toHandle: function () {
+        return {
+          compare: function (actual, event) {
+            if ( !actual || actual.length === 0 ) return { pass: false };
+            var events = $._data($(actual).get(0), "events")
+
+            if (!events || !event || typeof event !== "string") {
+              return { pass: false }
+            }
+
+            var namespaces = event.split(".")
+              , eventType = namespaces.shift()
+              , sortedNamespaces = namespaces.slice(0).sort()
+              , namespaceRegExp = new RegExp("(^|\\.)" + sortedNamespaces.join("\\.(?:.*\\.)?") + "(\\.|$)")
+
+            if (events[eventType] && namespaces.length) {
+              for (var i = 0; i < events[eventType].length; i++) {
+                var namespace = events[eventType][i].namespace
+
+                if (namespaceRegExp.test(namespace))
+                  return { pass: true }
+              }
+            } else {
+              return { pass: (events[eventType] && events[eventType].length > 0) }
+            }
+
+            return { pass: false }
+          }
+        }
+      },
+
+      toHandleWith: function () {
+        return {
+          compare: function (actual, eventName, eventHandler) {
+            if ( !actual || actual.length === 0 ) return { pass: false };
+            var normalizedEventName = eventName.split('.')[0]
+              , stack = $._data($(actual).get(0), "events")[normalizedEventName]
+
+            for (var i = 0; i < stack.length; i++) {
+              if (stack[i].handler == eventHandler) return { pass: true }
+            }
+
+            return { pass: false }
+          }
+        }
+      },
+
+      toHaveBeenTriggeredOn: function () {
+        return {
+          compare: function (actual, selector) {
+            var result = { pass: jasmine.jQuery.events.wasTriggered(selector, actual) }
+
+            result.message = result.pass ?
+              "Expected event " + $(actual) + " not to have been triggered on " + selector :
+              "Expected event " + $(actual) + " to have been triggered on " + selector
+
+            return result;
+          }
+        }
+      },
+
+      toHaveBeenTriggered: function (){
+        return {
+          compare: function (actual) {
+            var eventName = actual.eventName
+              , selector = actual.selector
+              , result = { pass: jasmine.jQuery.events.wasTriggered(selector, eventName) }
+
+            result.message = result.pass ?
+            "Expected event " + eventName + " not to have been triggered on " + selector :
+              "Expected event " + eventName + " to have been triggered on " + selector
+
+            return result
+          }
+        }
+      },
+
+      toHaveBeenTriggeredOnAndWith: function (j$, customEqualityTesters) {
+        return {
+          compare: function (actual, selector, expectedArgs) {
+            var wasTriggered = jasmine.jQuery.events.wasTriggered(selector, actual)
+              , result = { pass: wasTriggered && jasmine.jQuery.events.wasTriggeredWith(selector, actual, expectedArgs, j$, customEqualityTesters) }
+
+              if (wasTriggered) {
+                var actualArgs = jasmine.jQuery.events.args(selector, actual, expectedArgs)[1]
+                result.message = result.pass ?
+                  "Expected event " + actual + " not to have been triggered with " + jasmine.pp(expectedArgs) + " but it was triggered with " + jasmine.pp(actualArgs) :
+                  "Expected event " + actual + " to have been triggered with " + jasmine.pp(expectedArgs) + "  but it was triggered with " + jasmine.pp(actualArgs)
+
+              } else {
+                // todo check on this
+                result.message = result.pass ?
+                  "Expected event " + actual + " not to have been triggered on " + selector :
+                  "Expected event " + actual + " to have been triggered on " + selector
+              }
+
+              return result
+          }
+        }
+      },
+
+      toHaveBeenPreventedOn: function () {
+        return {
+          compare: function (actual, selector) {
+            var result = { pass: jasmine.jQuery.events.wasPrevented(selector, actual) }
+
+            result.message = result.pass ?
+              "Expected event " + actual + " not to have been prevented on " + selector :
+              "Expected event " + actual + " to have been prevented on " + selector
+
+            return result
+          }
+        }
+      },
+
+      toHaveBeenPrevented: function () {
+        return {
+          compare: function (actual) {
+            var eventName = actual.eventName
+              , selector = actual.selector
+              , result = { pass: jasmine.jQuery.events.wasPrevented(selector, eventName) }
+
+            result.message = result.pass ?
+              "Expected event " + eventName + " not to have been prevented on " + selector :
+              "Expected event " + eventName + " to have been prevented on " + selector
+
+            return result
+          }
+        }
+      },
+
+      toHaveBeenStoppedOn: function () {
+        return {
+          compare: function (actual, selector) {
+            var result = { pass: jasmine.jQuery.events.wasStopped(selector, actual) }
+
+            result.message = result.pass ?
+              "Expected event " + actual + " not to have been stopped on " + selector :
+              "Expected event " + actual + " to have been stopped on " + selector
+
+            return result;
+          }
+        }
+      },
+
+      toHaveBeenStopped: function () {
+        return {
+          compare: function (actual) {
+            var eventName = actual.eventName
+              , selector = actual.selector
+              , result = { pass: jasmine.jQuery.events.wasStopped(selector, eventName) }
+
+            result.message = result.pass ?
+              "Expected event " + eventName + " not to have been stopped on " + selector :
+              "Expected event " + eventName + " to have been stopped on " + selector
+
+            return result
+          }
+        }
+      }
+    })
+
+    jasmine.getEnv().addCustomEqualityTester(function(a, b) {
+     if (a && b) {
+       if (a instanceof $ || jasmine.isDomNode(a)) {
+         var $a = $(a)
+
+         if (b instanceof $)
+           return $a.length == b.length && $a.is(b)
+
+         return $a.is(b);
+       }
+
+       if (b instanceof $ || jasmine.isDomNode(b)) {
+         var $b = $(b)
+
+         if (a instanceof $)
+           return a.length == $b.length && $b.is(a)
+
+         return $b.is(a);
+       }
+     }
+    })
+
+    jasmine.getEnv().addCustomEqualityTester(function (a, b) {
+     if (a instanceof $ && b instanceof $ && a.size() == b.size())
+        return a.is(b)
+    })
+  })
+
+  afterEach(function () {
+    jasmine.getFixtures().cleanUp()
+    jasmine.getStyleFixtures().cleanUp()
+    jasmine.jQuery.events.cleanUp()
+  })
+
+  window.readFixtures = function () {
+    return jasmine.getFixtures().proxyCallTo_('read', arguments)
+  }
+
+  window.preloadFixtures = function () {
+    jasmine.getFixtures().proxyCallTo_('preload', arguments)
+  }
+
+  window.loadFixtures = function () {
+    jasmine.getFixtures().proxyCallTo_('load', arguments)
+  }
+
+  window.appendLoadFixtures = function () {
+    jasmine.getFixtures().proxyCallTo_('appendLoad', arguments)
+  }
+
+  window.setFixtures = function (html) {
+    return jasmine.getFixtures().proxyCallTo_('set', arguments)
+  }
+
+  window.appendSetFixtures = function () {
+    jasmine.getFixtures().proxyCallTo_('appendSet', arguments)
+  }
+
+  window.sandbox = function (attributes) {
+    return jasmine.getFixtures().sandbox(attributes)
+  }
+
+  window.spyOnEvent = function (selector, eventName) {
+    return jasmine.jQuery.events.spyOn(selector, eventName)
+  }
+
+  window.preloadStyleFixtures = function () {
+    jasmine.getStyleFixtures().proxyCallTo_('preload', arguments)
+  }
+
+  window.loadStyleFixtures = function () {
+    jasmine.getStyleFixtures().proxyCallTo_('load', arguments)
+  }
+
+  window.appendLoadStyleFixtures = function () {
+    jasmine.getStyleFixtures().proxyCallTo_('appendLoad', arguments)
+  }
+
+  window.setStyleFixtures = function (html) {
+    jasmine.getStyleFixtures().proxyCallTo_('set', arguments)
+  }
+
+  window.appendSetStyleFixtures = function (html) {
+    jasmine.getStyleFixtures().proxyCallTo_('appendSet', arguments)
+  }
+
+  window.loadJSONFixtures = function () {
+    return jasmine.getJSONFixtures().proxyCallTo_('load', arguments)
+  }
+
+  window.getJSONFixture = function (url) {
+    return jasmine.getJSONFixtures().proxyCallTo_('read', arguments)[url]
+  }
+}));

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -1,14 +1,17 @@
 src_files:
-    - src/events/ab_bucket_store.js
-    - src/popup/lib/jquery.min.js
-    - src/popup/ab_tests.js
-    - src/popup/content_links.js
-    - src/popup/environment.js
-    - src/popup/extract_path.js
-    - src/popup/external_links.js
+  - src/events/ab_bucket_store.js
+  - src/popup/lib/jquery.min.js
+  - src/popup/ab_tests.js
+  - src/popup/content_links.js
+  - src/popup/environment.js
+  - src/popup/extract_path.js
+  - src/popup/external_links.js
+  - src/highlight-component.js
 
 helpers:
-    - support/helpers.js
+  - support/helpers.js
+  - support/jasmine-jquery.js
+  - support/polyfills/String.startsWith.js
 
 spec_files:
   - '**/*[sS]pec.js'

--- a/spec/javascripts/support/polyfills/String.startsWith.js
+++ b/spec/javascripts/support/polyfills/String.startsWith.js
@@ -1,0 +1,5 @@
+if (!String.prototype.startsWith) {
+  String.prototype.startsWith = function(searchString, position){
+    return this.substr(position || 0, searchString.length) === searchString;
+  };
+}

--- a/src/fetch-page-data.js
+++ b/src/fetch-page-data.js
@@ -6,7 +6,8 @@ chrome.runtime.sendMessage({
   action: "populatePopup",
   currentLocation: window.location,
   renderingApplication: getMetatag('govuk:rendering-application'),
-  abTestBuckets: getAbTestBuckets()
+  abTestBuckets: getAbTestBuckets(),
+  highlightState: window.highlightComponent.state
 });
 
 function getMetatag(name) {

--- a/src/highlight-component.css
+++ b/src/highlight-component.css
@@ -1,0 +1,20 @@
+.highlight-component {
+  cursor: pointer;
+  outline: 3px solid #FFBF47;
+  position: relative;
+}
+
+.highlight-component::before {
+  background-color: #FFBF47;
+  color: #0B0C0C;
+  content: attr(data-app-name)attr(data-component-name);
+  font-family: sans-serif;
+  font-size: 16px;
+  font-weight: normal;
+
+  padding-left: 3px;
+  padding-bottom: 3px;
+  position: absolute;
+  right: 0;
+  top: 0;
+}

--- a/src/highlight-component.js
+++ b/src/highlight-component.js
@@ -1,0 +1,83 @@
+'use strict';
+
+function HighlightComponent() {
+  this.state = false;
+  this.components = extractComponentsFromPage();
+
+  function extractComponentsFromPage() {
+    return $('[class*="app-c"], [class*="pub-c"], [class*="govuk"]')
+      .toArray()
+      .reduce(function(array, element) {
+        var blockRegex = /(app-c-|pub-c-|govuk-c-|govuk-)([^ _\n]*(?=[ \n]|$))/;
+        var match = $(element).attr('class').match(blockRegex);
+
+        if (match) {
+          array.push({
+            element: element,
+            prefix: match[1],
+            name: match[2]
+          });
+        }
+
+        return array
+      }, []);
+  }
+
+  this.components.forEach(setupComponent.bind(this));
+
+  function setupComponent(component) {
+    var $element = $(component.element);
+    $element.attr('data-component-name', component.name);
+    $element.attr('data-app-name', component.prefix);
+
+    $element.on('click', function() {
+      if (this.state) {
+        window.open( Helpers.documentationUrl(component) );
+      }
+    }.bind(this));
+  }
+
+  chrome.runtime.onMessage.addListener(function (request) {
+    if (request.trigger == 'toggleState') {
+      this.toggleState();
+    }
+  }.bind(this));
+}
+
+HighlightComponent.prototype.toggleState = function () {
+  this.state = !this.state;
+
+  for (var i = 0; i < this.components.length; i++) {
+    $(this.components[i].element).toggleClass('highlight-component', this.state);
+  }
+
+  this.sendState();
+}
+
+HighlightComponent.prototype.sendState = function() {
+  chrome.runtime.sendMessage({
+    action: "highlightState",
+    highlightState: this.state
+  });
+};
+
+var Helpers = {
+  documentationUrl: function (component) {
+    if (component.prefix.startsWith('app-c')) {
+      return "https://" + this.appHostname() + ".herokuapp.com/component-guide/" + component.name
+    } else {
+      return "https://govuk-static.herokuapp.com/component-guide/" + component.name.replace('-', '_');
+    }
+  },
+
+  substitutions: {
+    'collections': 'govuk-collections'
+  },
+
+  appHostname: function() {
+    var $rendering_element = $('meta[name="govuk:rendering-application"]');
+    var rendering_app = $rendering_element[0] && $rendering_element[0]['content'];
+    return this.substitutions[rendering_app] || rendering_app;
+  }
+
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,8 +9,10 @@
       "matches": ["https://*.gov.uk/*"],
       "js": [
         "popup/lib/jquery.min.js",
-        "popup/lib/mustache.min.js"
-      ]
+        "popup/lib/mustache.min.js",
+        "highlight-component.js"
+      ],
+      "css": ["highlight-component.css"]
     }
   ],
   "icons": {

--- a/src/popup.html
+++ b/src/popup.html
@@ -22,7 +22,12 @@
       {{/environments}}
     </div>
 
-    <ul class='content-links'>{{#contentLinks}}<li><a href="{{url}}" class="{{class}}">{{name}}</a></li>{{/contentLinks}}</ul>
+    <ul class='content-links'>
+      {{#contentLinks}}
+        <li><a href="{{url}}" class="internal {{class}}">{{name}}</a></li>
+      {{/contentLinks}}
+    </ul>
+
     {{#abTests.length}}
       <div class='ab-tests'>
         <ul>
@@ -34,10 +39,22 @@
             {{/buckets}}
           </li>
         {{/abTests}}
+
         </ul>
       </div>
     {{/abTests.length}}
-    <ul class='external-links'>{{#externalLinks}}<li><a href="{{url}}" class="external">{{{name}}}</a></li>{{/externalLinks}}</ul>
+
+    <ul class='add-top-border'>
+      {{#externalLinks}}
+        <li><a href="{{url}}" class="external">{{{name}}}</a></li>
+      {{/externalLinks}}
+    </ul>
+
+    <ul class='add-top-border'>
+      <li>
+        <a href='#' id='highlight-components'>Highlight Components</a>
+      </li>
+    </ul>
   </script>
 
   <div id="content">Loading...</div>

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -20,13 +20,13 @@ body {
   background-color: #005ea5;
 }
 
-.external-links {
+.add-top-border {
   margin-top: 10px;
   padding-top: 10px;
   border-top: 1px solid #ccc;
 }
 
-.external-links:empty {
+.add-top-border:empty {
   display: none;
 }
 


### PR DESCRIPTION


We hope to encourage re-use of design elements that are documented in
the component guides [1][2] by highlighting where they exist in the
page.

The user can toggle this functionlity on from the extension popup,
which will outline all the components in the page with a label of what
it is called. Clicking within the outline will navigate the user to
its documentation.

[1] https://govuk-static.herokuapp.com/component-guide
[2] https://government-frontend.herokuapp.com/component-guide

![out](https://user-images.githubusercontent.com/6050162/30977418-61608cfa-a46f-11e7-9a50-7ad2a847bc7e.gif)
