### PR TITLE
Register click events for switching environments

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -18,13 +18,13 @@
   <script id="template" type="x-tmpl-mustache">
     <div class='envs'>
       {{#environments}}
-        <a href="{{url}}" class="{{class}}">{{name}}</a>
+        <a href="{{url}}" class="js-rerender-popup {{class}}">{{name}}</a>
       {{/environments}}
     </div>
 
     <ul class='content-links'>
       {{#contentLinks}}
-        <li><a href="{{url}}" class="internal {{class}}">{{name}}</a></li>
+        <li><a href="{{url}}" class="js-rerender-popup {{class}}">{{name}}</a></li>
       {{/contentLinks}}
     </ul>
 
@@ -46,7 +46,7 @@
 
     <ul class='add-top-border'>
       {{#externalLinks}}
-        <li><a href="{{url}}" class="external">{{{name}}}</a></li>
+        <li><a href="{{url}}" class="js-external">{{{name}}}</a></li>
       {{/externalLinks}}
     </ul>
 

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -76,7 +76,7 @@ var Popup = Popup || {};
   function setupClicks(currentUrl) {
     // Clicking on a link won't open the tab because we're in a separate window.
     // Open external links (to GitHub etc) in a new tab.
-    $('a.external').on('click', function(e) {
+    $('a.js-external').on('click', function(e) {
       if (userOpensPageInNewWindow(e)) {
         return;
       }
@@ -86,7 +86,7 @@ var Popup = Popup || {};
 
     // Clicking normal links should change the current tab. The popup will not
     // update itself automatically, we need to re-render the popup manually.
-    $('a.internal').on('click', function(e) {
+    $('a.js-rerender-popup').on('click', function(e) {
       if (userOpensPageInNewWindow(e)) {
         return;
       }


### PR DESCRIPTION
In a previous release, the selector to attach click events was updated
to split apart internal and external links. However, the links that
changed the enviornments were missed and have since stopped working.

This has been resolved by adding an 'in-popup' class to all links in
the page that change the content in the current page.