### PR TITLE
Combine A/B test and highlight component toggles together

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -14,7 +14,7 @@
   <link href="popup/reset.css" rel="stylesheet" type="text/css">
   <link href="popup/popup.css" rel="stylesheet" type="text/css">
 </head>
-<body style="width: 550px;">
+<body>
   <script id="template" type="x-tmpl-mustache">
     <div class='envs'>
       {{#environments}}
@@ -28,32 +28,24 @@
       {{/contentLinks}}
     </ul>
 
-    {{#abTests.length}}
-      <div class='ab-tests'>
-        <ul>
-        {{#abTests}}
-          <li>
-            <span class='ab-test-name'>A/B test: <strong>{{testName}}</strong></span>
-            {{#buckets}}
-              <span class='ab-test-bucket {{class}}' data-test-name='{{testName}}' data-bucket='{{bucketName}}'>{{bucketName}}</span>
-            {{/buckets}}
-          </li>
-        {{/abTests}}
-
-        </ul>
-      </div>
-    {{/abTests.length}}
+    <ul class='add-top-border'>
+      <li>
+        <a href='#' id='highlight-components'>Highlight Components</a>
+      </li>
+      {{#abTests}}
+        <li>
+          <span class='ab-test-name'>A/B test: <strong>{{testName}}</strong></span>
+          {{#buckets}}
+            <span class='ab-test-bucket {{class}}' data-test-name='{{testName}}' data-bucket='{{bucketName}}'>{{bucketName}}</span>
+          {{/buckets}}
+        </li>
+      {{/abTests}}
+    </ul>
 
     <ul class='add-top-border'>
       {{#externalLinks}}
         <li><a href="{{url}}" class="js-external">{{{name}}}</a></li>
       {{/externalLinks}}
-    </ul>
-
-    <ul class='add-top-border'>
-      <li>
-        <a href='#' id='highlight-components'>Highlight Components</a>
-      </li>
     </ul>
   </script>
 

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -1,7 +1,7 @@
 body {
   margin: 0;
   padding: 0;
-  width: 200px;
+  width: 550px;
 }
 
 .envs {
@@ -45,12 +45,6 @@ li a.current,
 li a:hover {
   background-color: #005ea5;
   color: #fff;
-}
-
-.ab-tests {
-  margin-top: 10px;
-  padding-top: 10px;
-  border-top: 1px solid #ccc;
 }
 
 .ab-test-name, .ab-test-bucket {


### PR DESCRIPTION
The maximum height of the extension popup is 600px, which is visible
when a page has an active A/B test and the toggle displays in the
popup. We can save ourselves some space by combining this toggle with
the recent highlight component toggle.

Resolves https://github.com/alphagov/govuk-toolkit-chrome/issues/81

<img width="860" alt="screen shot 2017-10-03 at 14 24 32" src="https://user-images.githubusercontent.com/885223/31127402-bc7087aa-a846-11e7-8f9a-1db9f8688a70.png">
<img width="857" alt="screen shot 2017-10-03 at 14 25 17" src="https://user-images.githubusercontent.com/885223/31127403-bc753f66-a846-11e7-9b8b-3c45eded0f3c.png">

