### PR TITLE
Link directly to content item in whitehall

### DIFF
--- a/spec/javascripts/external_links_spec.js
+++ b/spec/javascripts/external_links_spec.js
@@ -137,6 +137,7 @@ describe("Popup.generateExternalLinks", function () {
 
   it("generates edit links for Whitehall items", function () {
     var contentItem = {
+      content_id: '4d8568c4-67f2-48da-a578-5ac6f35b69b4',
       publishing_app: 'whitehall'
     }
 
@@ -144,7 +145,7 @@ describe("Popup.generateExternalLinks", function () {
 
     expect(links).toContain({
       name: 'Go to Whitehall Publisher',
-      url: 'https://whitehall-admin.publishing.service.gov.uk/'
+      url: 'https://whitehall-admin.publishing.service.gov.uk/government/admin/by-content-id/4d8568c4-67f2-48da-a578-5ac6f35b69b4'
     })
   })
 

--- a/src/popup/external_links.js
+++ b/src/popup/external_links.js
@@ -96,7 +96,7 @@ function generateEditLink(contentItem, env) {
   } else if (contentItem.publishing_app == 'whitehall') {
     return {
       name: 'Go to Whitehall Publisher',
-      url: env.protocol + '://whitehall-admin.' + env.serviceDomain + '/',
+      url: env.protocol + '://whitehall-admin.' + env.serviceDomain + '/government/admin/by-content-id/' + contentItem.content_id,
     }
   } else if (contentItem.document_type == 'manual') {
     return {


### PR DESCRIPTION
This commit changes the “Go to whitehall” link to point directly to the relevant content item in whitehall rather than the homepage. This is enabled by the `/by-content-id` route in whitehall.

Trello: https://trello.com/c/DiAmzZPL/86-link-to-whitehall-from-the-chrome-extension

Addresses https://github.com/alphagov/govuk-toolkit-chrome/issues/74