### PR TITLE
Make the extension compatible with Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## GOV.UK Toolkit for Chrome
+## GOV.UK Toolkit for Chrome and Firefox
 
 Allows easy switching between the different GOV.UK environments and content representations. Inspired by the [govuk-bookmarklets](https://github.com/dsingleton/govuk-bookmarklets).
 
@@ -6,22 +6,38 @@ Allows easy switching between the different GOV.UK environments and content repr
 
 ### Installation
 
-The extension is [downloadable on the Chrome web store](https://chrome.google.com/webstore/detail/govuk-toolkit/dclfaikcemljbaoagjnedmlppnbiljen).
+The extension is [downloadable on the Chrome web store](https://chrome.google.com/webstore/detail/govuk-toolkit/dclfaikcemljbaoagjnedmlppnbiljen) and [AMO for Firefox](https://addons.mozilla.org/en-GB/firefox/addon/govuk-toolkit/).
 
-If you don't want to install from the web store for security reasons, you can install a non-self updating copy like this:
+If you don't want to install from your browser's web store for security reasons, you can install a local non-self updating copy.
 
-1. [Download the source from GitHub](https://github.com/tijmenb/govuk-toolkit-chrome/archive/master.zip) and unzip.
+#### For Chrome:
+
+1. [Download the source from GitHub](https://github.com/alphagov/govuk-toolkit-chrome/archive/master.zip) and unzip.
 2. Visit [chrome://extensions](chrome://extensions) in your browser.
 3. Ensure that the Developer mode checkbox in the top right-hand corner is checked.
-4. Click `Load unpacked extension…` to pop up a file-selection dialog.
+4. Click `Load unpacked extension…` to pop up a file selection dialog.
 5. Navigate to `src` in the extension directory, and select it.
-6. Visit any page on [gov.uk](https://gov.uk)
+6. Visit any page on [GOV.UK](https://www.gov.uk).
 
 Source: [Getting Started: Building a Chrome Extension](https://developer.chrome.com/extensions/getstarted#unpacked).
 
+#### For Firefox:
+
+Extensions installed using the following instructions are only active while Firefox
+is open and are removed on exit. Permanently-active extensions can be only be
+installed from packages signed by Mozilla.
+
+1. [Download the source from GitHub](https://github.com/alphagov/govuk-toolkit-chrome/archive/master.zip) and unzip.
+2. Visit [about:debugging](about:debugging) in your browser.
+4. Click `Load Temporary Add-on` to pop up a file selection dialog.
+5. Navigate to `src` in the extension directory, and select `manifest.json`.
+6. Visit any page on [GOV.UK](https://www.gov.uk).
+
+Source: [Temporary installation in Firefox](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Temporary_Installation_in_Firefox).
+
 ### Running the tests
 
-In development it's easiest to run:
+In development, it's easiest to run:
 
 ```
 $ bundle exec rake jasmine
@@ -39,7 +55,7 @@ $ bundle exec rake jasmine:ci
 
 1. Update the version in `manifest.json`
 2. Run `rake build`
-3. Upload newly created package in `/build` to the [Chrome web store](https://chrome.google.com/webstore/developer/edit/dclfaikcemljbaoagjnedmlppnbiljen). The extension is currently on [Tijmen's](https://github.com/tijmenb) account.
+3. Upload newly created package in `/build` to the [Chrome web store](https://chrome.google.com/webstore/developer/edit/dclfaikcemljbaoagjnedmlppnbiljen) (currently on [Tijmen's](https://github.com/tijmenb) account) and [AMO](https://addons.mozilla.org/en-US/developers/addon/da5cfa61532d478ea212/versions/submit/) (account details in the [2nd line password store](https://github.com/alphagov/govuk-secrets/tree/master/pass/2ndline/firefox)).
 4. Create a [new release on GitHub](https://github.com/alphagov/govuk-toolkit-chrome/releases/new)
 
 ### License

--- a/spec/javascripts/content_links_spec.js
+++ b/spec/javascripts/content_links_spec.js
@@ -3,7 +3,9 @@ describe("PopupView.generateContentLinks", function () {
 
   it("returns the correct URIs", function () {
     var links = Popup.generateContentLinks(
-      stubLocation("https://www.gov.uk/browse/disabilities?foo=bar"),
+      "https://www.gov.uk/browse/disabilities?foo=bar",
+      "https://www.gov.uk",
+      "/browse/disabilities",
       PROD_ENV
     )
 
@@ -22,7 +24,9 @@ describe("PopupView.generateContentLinks", function () {
 
   it("returns the draft URIs for non-prod environments", function () {
     var links = Popup.generateContentLinks(
-      stubLocation("https://www.gov.uk/browse/disabilities?foo=bar"),
+      "https://www.gov.uk/browse/disabilities?foo=bar",
+      "https://www.gov.uk",
+      "/browse/disabilities",
       { protocol: 'https', serviceDomain: 'staging.publishing.service.gov.uk'}
     )
 
@@ -35,7 +39,9 @@ describe("PopupView.generateContentLinks", function () {
 
   it("generates a subset of URIs for the root page", function () {
     var links = Popup.generateContentLinks(
-      stubLocation("https://www.gov.uk/"),
+      "https://www.gov.uk/",
+      "https://www.gov.uk",
+      "/",
       PROD_ENV
     )
 
@@ -49,7 +55,9 @@ describe("PopupView.generateContentLinks", function () {
 
   it("does not generate URIs for publishing apps (non-www pages)", function () {
     var links = Popup.generateContentLinks(
-      stubLocation("https://search-admin.publishing.service.gov.uk/queries"),
+      "https://search-admin.publishing.service.gov.uk/queries",
+      "https://search-admin.publishing.service.gov.uk",
+      "/queries",
       PROD_ENV
     )
 
@@ -58,7 +66,9 @@ describe("PopupView.generateContentLinks", function () {
 
   it("only generates URLs for publishing-apps when it's the support application", function () {
     var links = Popup.generateContentLinks(
-      stubLocation("https://support.publishing.service.gov.uk/anonymous_feedback?path=/browse/disabilities"),
+      "https://support.publishing.service.gov.uk/anonymous_feedback?path=/browse/disabilities",
+      "https://support.publishing.service.gov.uk",
+      "/anonymous_feedback",
       PROD_ENV
     )
 
@@ -77,7 +87,9 @@ describe("PopupView.generateContentLinks", function () {
 
   it("generates a link for smart answers", function () {
     var links = Popup.generateContentLinks(
-      stubLocation("https://www.gov.uk/smart-answer/y/question-1"),
+      "https://www.gov.uk/smart-answer/y/question-1",
+      "https://www.gov.uk",
+      "/smart-answer/y/question-1",
       PROD_ENV,
       "smartanswers"
     )
@@ -92,7 +104,9 @@ describe("PopupView.generateContentLinks", function () {
 
   it("does not generate a markdown link for landing pages", function () {
     var links = Popup.generateContentLinks(
-      stubLocation("https://www.gov.uk/smart-answer"),
+      "https://www.gov.uk/smart-answer",
+      "https://www.gov.uk",
+      "/smart-answer",
       PROD_ENV,
       "smartanswers"
     )

--- a/spec/javascripts/environment_spec.js
+++ b/spec/javascripts/environment_spec.js
@@ -1,6 +1,8 @@
 describe("Popup.environment", function() {
   function createEnvironmentForUrl(location) {
-    return Popup.environment(stubLocation(location)).allEnvironments;
+    var a = document.createElement('a');
+    a.href = location;
+    return Popup.environment(a.href, a.host, a.origin).allEnvironments;
   }
 
   it("returns the correct environment links when the user is on production", function() {

--- a/spec/javascripts/extract_path_spec.js
+++ b/spec/javascripts/extract_path_spec.js
@@ -1,66 +1,66 @@
 describe("Popup.extractPath", function () {
   it("returns nothing for publishing applications", function () {
-    var path = Popup.extractPath(stubLocation("https://publisher.publishing.service.gov.uk/foo/bar"))
+    var path = Popup.extractPath("https://publisher.publishing.service.gov.uk/foo/bar", "/foo/bar")
 
     expect(path).toBeUndefined();
   })
 
   it("returns the path for draft URLs", function () {
-    var path = Popup.extractPath(stubLocation("https://draft-origin.staging.publishing.service.gov.uk/browse/disabilities"))
+    var path = Popup.extractPath("https://draft-origin.staging.publishing.service.gov.uk/browse/disabilities", "/browse/disabilities")
 
     expect(path).toEqual("/browse/disabilities");
   })
 
   it("returns the path for frontend applications", function () {
-    var path = Popup.extractPath(stubLocation("https://www.gov.uk/browse/disabilities"))
+    var path = Popup.extractPath("https://www.gov.uk/browse/disabilities", "/browse/disabilities")
 
     expect(path).toBe("/browse/disabilities")
   })
 
   it("returns the path for origin frontend applications", function () {
-    var path = Popup.extractPath(stubLocation("https://www-origin.gov.uk/browse/disabilities"))
+    var path = Popup.extractPath("https://www-origin.gov.uk/browse/disabilities", "/browse/disabilities")
 
     expect(path).toBe("/browse/disabilities")
   })
 
   it("returns the path for content-store pages", function () {
-    var path = Popup.extractPath(stubLocation("https://www.gov.uk/api/content/browse/disabilities"))
+    var path = Popup.extractPath("https://www.gov.uk/api/content/browse/disabilities", "/api/content/browse/disabilities")
 
     expect(path).toBe("/browse/disabilities")
   })
 
   it("returns the path for URLs with double slashes", function () {
-    var path = Popup.extractPath(stubLocation("https://www.gov.uk/api/content//browse/disabilities"))
+    var path = Popup.extractPath("https://www.gov.uk/api/content//browse/disabilities", "/api/content//browse/disabilities")
 
     expect(path).toBe("/browse/disabilities")
   })
 
   it("returns the path for info pages", function () {
-    var path = Popup.extractPath(stubLocation("https://www.gov.uk/info/browse/disabilities"))
+    var path = Popup.extractPath("https://www.gov.uk/info/browse/disabilities", "/info/browse/disabilities")
 
     expect(path).toBe("/browse/disabilities")
   })
 
   it("returns the path for search pages", function () {
-    var path = Popup.extractPath(stubLocation("https://www.gov.uk/api/search.json?filter_link=/browse/disabilities"))
+    var path = Popup.extractPath("https://www.gov.uk/api/search.json?filter_link=/browse/disabilities", "/api/search.json")
 
     expect(path).toBe("/browse/disabilities")
   })
 
   it("returns the path for cache-busted search pages", function () {
-    var path = Popup.extractPath(stubLocation("https://www.gov.uk/api/search.json?filter_link=/browse/disabilities&c=some_cache_buster"))
+    var path = Popup.extractPath("https://www.gov.uk/api/search.json?filter_link=/browse/disabilities&c=some_cache_buster", "/api/search.json")
 
     expect(path).toBe("/browse/disabilities")
   })
 
   it("returns the path for national archives pages", function () {
-    var path = Popup.extractPath(stubLocation("http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk/some/page"))
+    var path = Popup.extractPath("http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk/some/page", "/*/https://www.gov.uk/some/page")
 
     expect(path).toBe("/some/page")
   })
 
   it("returns the path for the smart answers visualisation", function () {
-    var path = Popup.extractPath(stubLocation("https://www.gov.uk/maternity-paternity-calculator/y/visualise"))
+    var path = Popup.extractPath("https://www.gov.uk/maternity-paternity-calculator/y/visualise", "/maternity-paternity-calculator/y/visualise")
 
     expect(path).toBe("/maternity-paternity-calculator")
   })

--- a/spec/javascripts/support/helpers.js
+++ b/spec/javascripts/support/helpers.js
@@ -3,9 +3,3 @@ function pluck(array, key) {
     return object[key];
   })
 }
-
-function stubLocation(url) {
-  var location = document.createElement('a');
-  location.href = url;
-  return location;
-}

--- a/src/fetch-page-data.js
+++ b/src/fetch-page-data.js
@@ -4,7 +4,10 @@
 
 chrome.runtime.sendMessage({
   action: "populatePopup",
-  currentLocation: window.location,
+  currentLocation: window.location.href,
+  currentHost: window.location.host,
+  currentOrigin: window.location.origin,
+  currentPathname: window.location.pathname,
   renderingApplication: getMetatag('govuk:rendering-application'),
   abTestBuckets: getAbTestBuckets(),
   highlightState: window.highlightComponent.state
@@ -36,3 +39,5 @@ function getAbTestBuckets() {
 
   return buckets;
 }
+
+undefined;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -24,6 +24,7 @@
     "http://*.gov.uk/*",
     "https://*.gov.uk/*",
     "cookies",
+    "tabs",
     "webRequest",
     "webRequestBlocking"
   ],

--- a/src/popup.html
+++ b/src/popup.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
   <script src='popup/lib/mustache.min.js'></script>
   <script src='popup/lib/jquery.min.js'></script>
 

--- a/src/popup/content_links.js
+++ b/src/popup/content_links.js
@@ -1,8 +1,8 @@
 var Popup = Popup || {};
 
 // Given a location, generate links to different content presentations
-Popup.generateContentLinks = function(location, currentEnvironment, renderingApplication) {
-  var path = Popup.extractPath(location, renderingApplication);
+Popup.generateContentLinks = function(location, origin, pathname, currentEnvironment, renderingApplication) {
+  var path = Popup.extractPath(location, pathname, renderingApplication);
 
   // If no path can be found (which means we're probably in a publishing app)
   if (!path) {
@@ -10,28 +10,26 @@ Popup.generateContentLinks = function(location, currentEnvironment, renderingApp
   }
 
   // This is 'https://www.gov.uk' or 'https://www-origin.integration.publishing.service.gov.uk/', etc.
-  var originHost = location.origin;
-
-  if (originHost == 'http://webarchive.nationalarchives.gov.uk' || originHost.match(/draft-origin/) || originHost.match(/support/)) {
-    originHost = "https://www.gov.uk"
+  if (origin == 'http://webarchive.nationalarchives.gov.uk' || origin.match(/draft-origin/) || origin.match(/support/)) {
+    origin = "https://www.gov.uk"
   }
 
   var links = []
 
   // If we're on the homepage there's not much to show.
-  links.push({ name: "On GOV.UK", url: originHost + path })
+  links.push({ name: "On GOV.UK", url: origin + path })
 
   if (path != '/') {
-    links.push({ name: "Content item (JSON)", url: originHost + "/api/content" + path })
-    links.push({ name: "Search data (JSON)", url: originHost + "/api/search.json?filter_link=" + path })
-    links.push({ name: "Info page", url: originHost + "/info" + path })
+    links.push({ name: "Content item (JSON)", url: origin + "/api/content" + path })
+    links.push({ name: "Search data (JSON)", url: origin + "/api/search.json?filter_link=" + path })
+    links.push({ name: "Info page", url: origin + "/info" + path })
     links.push({ name: "Draft (may not always work)", url: currentEnvironment.protocol + '://draft-origin.' + currentEnvironment.serviceDomain + path })
     links.push({ name: "User feedback", url: currentEnvironment.protocol + '://support.' + currentEnvironment.serviceDomain + '/anonymous_feedback?path=' + path })
   }
 
   links.push({ name: "National Archives", url: "http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk" + path })
 
-  var currentUrl = originHost + path;
+  var currentUrl = origin + path;
 
   if (renderingApplication == "smartanswers") {
     if (currentUrl.match(/\/y\/?.*$/)) {
@@ -42,7 +40,7 @@ Popup.generateContentLinks = function(location, currentEnvironment, renderingApp
   }
 
   return links.map(function (link) {
-    link.class = link.url == location.href ? "current" : ""
+    link.class = link.url == location ? "current" : ""
     return link;
   })
 }

--- a/src/popup/environment.js
+++ b/src/popup/environment.js
@@ -1,15 +1,15 @@
 var Popup = Popup || {};
 
-// Given a location, generate URLs for all GOV.UK environments.
+// Given a location, host and origin, generate URLs for all GOV.UK environments.
 //
 // Returns a hash with envs, including one with `class: "current"` to show
 // the current environment.
-Popup.environment = function(location) {
+Popup.environment = function(location, host, origin) {
 
   function isPartOfGOVUK() {
-    return location.host.match(/www.gov.uk/) ||
-        location.host.match(/publishing.service.gov.uk/) ||
-        location.host.match(/dev.gov.uk/);
+    return host.match(/www.gov.uk/) ||
+        host.match(/publishing.service.gov.uk/) ||
+        host.match(/dev.gov.uk/);
   }
 
   if (!isPartOfGOVUK()) {
@@ -55,7 +55,7 @@ Popup.environment = function(location) {
     host: "https://www-origin.publishing.service.gov.uk"
   };
 
-  var application = location.host.split('.')[0],
+  var application = host.split('.')[0],
   inFrontend = application.match(/www/),
   environments = ENVIRONMENTS;
 
@@ -72,9 +72,9 @@ Popup.environment = function(location) {
       var replacement = env.protocol + "://" + application + "." + env.serviceDomain;
     }
 
-    env.url = location.href.replace(location.origin, replacement);
+    env.url = location.replace(origin, replacement);
 
-    if (location.href == env.url) {
+    if (location == env.url) {
       env.class = "current";
       currentEnvironment = env;
     } else {

--- a/src/popup/extract_path.js
+++ b/src/popup/extract_path.js
@@ -2,32 +2,32 @@ var Popup = Popup || {};
 
 // Extract the relevant path from a location, such as `/foo` from URLs like
 // `www.gov.uk/foo` and `www.gov.uk/api/content/foo`.
-Popup.extractPath = function(location, renderingApplication) {
+Popup.extractPath = function(location, pathname, renderingApplication) {
   var extractedPath;
 
-  if (location.href.match(/api\/content/)) {
-    extractedPath = location.pathname.replace('api/content/', '');
+  if (location.match(/api\/content/)) {
+    extractedPath = pathname.replace('api/content/', '');
   }
-  else if (location.href.match(/anonymous_feedback/)) {
+  else if (location.match(/anonymous_feedback/)) {
     extractedPath = extractQueryParameter(location, 'path');
   }
-  else if (location.href.match(/nationalarchives.gov.uk/)) {
-    extractedPath = location.pathname.split('https://www.gov.uk')[1];
+  else if (location.match(/nationalarchives.gov.uk/)) {
+    extractedPath = pathname.split('https://www.gov.uk')[1];
   }
-  else if (location.href.match(/api\/search.json/)) {
+  else if (location.match(/api\/search.json/)) {
     extractedPath = extractQueryParameter(location, 'filter_link');
   }
-  else if (location.href.match(/info/)) {
-    extractedPath = location.pathname.replace('info/', '');
+  else if (location.match(/info/)) {
+    extractedPath = pathname.replace('info/', '');
   }
-  else if (location.href.match(/api.*\.json/)) {
-    extractedPath = location.pathname.replace('api/', '').replace('.json', '');
+  else if (location.match(/api.*\.json/)) {
+    extractedPath = pathname.replace('api/', '').replace('.json', '');
   }
-  else if (location.href.match(/visualise/)) {
-    extractedPath = location.pathname.replace('/y/visualise', '');
+  else if (location.match(/visualise/)) {
+    extractedPath = pathname.replace('/y/visualise', '');
   }
-  else if (location.href.match(/www/) || location.href.match(/draft-origin/)) {
-    extractedPath = location.pathname;
+  else if (location.match(/www/) || location.match(/draft-origin/)) {
+    extractedPath = pathname;
   }
 
   if (extractedPath) {
@@ -35,6 +35,6 @@ Popup.extractPath = function(location, renderingApplication) {
   }
 
   function extractQueryParameter(location, parameter_name) {
-    return location.href.split(parameter_name + '=')[1].split('&')[0];
+    return location.split(parameter_name + '=')[1].split('&')[0];
   }
 }

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -2,6 +2,7 @@ body {
   margin: 0;
   padding: 0;
   width: 550px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 
 .envs {


### PR DESCRIPTION
This PR adds compatibility with Firefox by changing some aspects of the extension while keeping compatibility with Chrome. This is possible since Firefox supports substantially the same extension API as Chrome.

Trello: https://trello.com/c/5g5lCG9G/71-make-the-chrome-extension-work-in-firefox