### PR TITLE
Add 'gem-c' to include component gem components

### DIFF
--- a/spec/javascripts/fixtures/gem-c-label.html
+++ b/spec/javascripts/fixtures/gem-c-label.html
@@ -1,0 +1,5 @@
+<div class="gem-c-label">
+  <label class="gem-c-label__text" for="id-that-matches-input">
+    National Insurance number
+  </label>
+</div>

--- a/spec/javascripts/highlight_component_spec.js
+++ b/spec/javascripts/highlight_component_spec.js
@@ -86,7 +86,8 @@ describe("highlightComponent", function () {
       loadFixtures(
         "app-c-back-to-top.html",
         "govuk-breadcrumbs.html",
-        "pub-c-button.html"
+        "pub-c-button.html",
+        "gem-c-label.html"
       )
 
       $html = $("#jasmine-fixtures");
@@ -112,6 +113,11 @@ describe("highlightComponent", function () {
             prefix: "pub-c-",
             element: $html.find(".pub-c-button")[0],
           },
+          {
+            name: "label",
+            prefix: "gem-c-",
+            element: $html.find(".gem-c-label")[0],
+          }
         ]
       )
     });
@@ -187,6 +193,21 @@ describe("Helpers.documentationUrl", function () {
       })
     ).toEqual(
       "https://govuk-static.herokuapp.com/component-guide/title"
+    )
+  });
+
+  it("creates the correct URL for 'gem' components", function () {
+    setFixtures('<head><meta name="govuk:rendering-application" content="rendering_app"></head>');
+    Helpers.substitutions =  {
+      'collections': 'another_host'
+    };
+    expect(
+      Helpers.documentationUrl({
+        prefix: "gem-c",
+        name: "label"
+      })
+    ).toEqual(
+      "https://rendering_app.herokuapp.com/component-guide/label"
     )
   });
 

--- a/src/highlight-component.js
+++ b/src/highlight-component.js
@@ -5,10 +5,10 @@ function HighlightComponent() {
   this.components = extractComponentsFromPage();
 
   function extractComponentsFromPage() {
-    return $('[class*="app-c"], [class*="pub-c"], [class*="govuk"]')
+    return $('[class*="app-c"], [class*="pub-c"], [class*="gem-c"], [class*="govuk"]')
       .toArray()
       .reduce(function(array, element) {
-        var blockRegex = /(app-c-|pub-c-|govuk-c-|govuk-)([^ _\n]*(?=[ \n]|$))/;
+        var blockRegex = /(app-c-|pub-c-|gem-c-|govuk-c-|govuk-)([^ _\n]*(?=[ \n]|$))/;
         var match = $(element).attr('class').match(blockRegex);
 
         if (match) {
@@ -65,8 +65,10 @@ var Helpers = {
   documentationUrl: function (component) {
     if (component.prefix.startsWith('app-c')) {
       return "https://" + this.appHostname() + ".herokuapp.com/component-guide/" + component.name
+    } else if (component.prefix.startsWith('gem-c')) {
+      return "https://" + this.appHostname() + ".herokuapp.com/component-guide/" + component.name.replace(/-/g, '_');
     } else {
-      return "https://govuk-static.herokuapp.com/component-guide/" + component.name.replace('-', '_');
+      return "https://govuk-static.herokuapp.com/component-guide/" + component.name.replace(/-/g, '_');
     }
   },
 


### PR DESCRIPTION
Update the extension to include highlighting for components using the 'gem-c' namespace, i.e. components in the [govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components) gem. 

Result:

![screen shot 2018-01-11 at 10 23 47](https://user-images.githubusercontent.com/861310/34820814-8d3b6286-f6b9-11e7-82c0-e467ee40203f.png)
