### PR TITLE
Highlight meta tags

### DIFF
--- a/spec/javascripts/fixtures/meta-tags.html
+++ b/spec/javascripts/fixtures/meta-tags.html
@@ -1,0 +1,8 @@
+<head>
+  <meta name="foo" content="bar">
+  <meta name="govuk:format" content="something">
+  <meta property="og:image" content="https://assets.publishing.service.gov.uk/static/opengraph-image-a1f7d89ffd0782738b1aeb0da37842d8bd0addbd724b8e58c3edbc7287cc11de.png">
+</head>
+<body>
+  <h1>Content</h1>
+</body>

--- a/spec/javascripts/highlight_component_spec.js
+++ b/spec/javascripts/highlight_component_spec.js
@@ -7,12 +7,12 @@ describe("Toggling component highlighting", function () {
   beforeEach(function () {
     loadFixtures("govuk-breadcrumbs.html")
 
-    // Mock addListener function to call toggleState trigger when initialized
+    // Mock addListener function to call toggleComponents trigger when initialized
     window.chrome = {
       runtime: {
         onMessage: {
           addListener: function(callback) {
-            callback({ trigger: 'toggleState' })
+            callback({ trigger: 'toggleComponents' })
           }
         },
         sendMessage: function(){}
@@ -49,14 +49,14 @@ describe("Toggling component highlighting", function () {
   });
 
   it("removes the highlight when toggled off", function () {
-    highlightComponent.toggleState();
+    highlightComponent.toggleComponents();
 
     expect($breadcrumbsEl).not.toHaveClass("highlight-component");
   });
 
   it("removes the click functionality when toggled off", function () {
     spyOn(window, "open").and.callThrough()
-    highlightComponent.toggleState();
+    highlightComponent.toggleComponents();
 
     var clickEvent = spyOnEvent($breadcrumbsEl, "click");
 
@@ -123,17 +123,17 @@ describe("highlightComponent", function () {
     });
   });
 
-  describe("toggleState", function () {
+  describe("toggleComponents", function () {
     it("toggles the internal state", function () {
 
       var highlightComponent = new HighlightComponent;
 
       expect(highlightComponent.state).toEqual(false);
 
-      highlightComponent.toggleState();
+      highlightComponent.toggleComponents();
       expect(highlightComponent.state).toEqual(true);
 
-      highlightComponent.toggleState();
+      highlightComponent.toggleComponents();
       expect(highlightComponent.state).toEqual(false);
     });
 
@@ -145,10 +145,10 @@ describe("highlightComponent", function () {
       var $buttonEl = $("#jasmine-fixtures .pub-c-button");
       expect($buttonEl).not.toHaveClass("highlight-component");
 
-      highlightComponent.toggleState();
+      highlightComponent.toggleComponents();
       expect($buttonEl).toHaveClass("highlight-component");
 
-      highlightComponent.toggleState();
+      highlightComponent.toggleComponents();
       expect($buttonEl).not.toHaveClass("highlight-component");
     });
   });

--- a/spec/javascripts/show_meta_tags_spec.js
+++ b/spec/javascripts/show_meta_tags_spec.js
@@ -1,0 +1,29 @@
+'use strict';
+describe("Toggling meta tags", function () {
+  var $bannerEl;
+  var highlightComponent;
+
+  beforeEach(function () {
+    loadFixtures("meta-tags.html")
+
+    highlightComponent = new HighlightComponent;
+    highlightComponent.toggleMetaTags();
+
+    $bannerEl = $("#govuk-chrome-toolkit-banner");
+  });
+
+  it("shows meta tags with name and content", function () {
+    expect($bannerEl.text()).toMatch(/foo/);
+  });
+
+  it("doesn't show meta tags that use property instead of name", function () {
+    // No particular reason for this, it just doesn't
+    expect($bannerEl.text()).not.toMatch(/og:image/);
+  });
+
+  it("removes the banner when toggled off", function () {
+    highlightComponent.toggleMetaTags();
+
+    expect($bannerEl.parent()).toHaveLength(0);
+  });
+});

--- a/src/highlight-component.js
+++ b/src/highlight-component.js
@@ -57,30 +57,52 @@ HighlightComponent.prototype.toggleComponents = function () {
   this.sendState();
 }
 
-HighlightComponent.prototype.toggleMetaTags = function () {
+HighlightComponent.prototype.toggleMetaTags = function() {
   this.metaTags = !this.metaTags;
 
   if(this.metaTags) {
-    var msgElm = document.createElement("div");
-    var selectElement = document.getElementsByTagName("title")[0];
-    var msg = "<p><strong>title (" + selectElement.innerHTML.length + "):</strong> " + selectElement.innerHTML + "</p>";
-    var codeSegments = document.getElementsByTagName("meta");
-
-    for (var i=0; i < codeSegments.length;i++) {
-      if (codeSegments[i].getAttribute("name") !== null) {
-        var strs = codeSegments[i].getAttribute("content");
-        msg += "<p><strong>" + codeSegments[i].getAttribute("name") + " (" + strs.length + "):</strong> " + strs + "</p>";
-      }
-    }
-
-    msgElm.innerHTML = '<div id="govuk-chrome-toolkit-banner" style="border:2px solid #000;background:#ffc;text-align:left;padding:1em;">' + msg + "</div>";
-    document.body.insertBefore(msgElm, document.body.firstChild);
+    this.showMetaTags();
   } else {
-    $('#govuk-chrome-toolkit-banner').remove();
+    this.hideMetaTags();
   }
 
   this.sendState();
 };
+
+HighlightComponent.prototype.showMetaTags = function() {
+  var container = $('<div id="govuk-chrome-toolkit-banner" style="border:2px solid #000;background:#ffc;text-align:left;padding:1em;"></div>');
+
+  var titleText = $("title").first().text();
+  var strongElement = $('<strong></strong>').text("title (" + titleText.length + "): ");
+  var textNode = document.createTextNode(titleText);
+  $('<p>').append(strongElement).append(textNode).appendTo(container);
+
+  var metaTags = $("meta");
+  metaTags.each(function() {
+    var metaTag = $(this);
+
+    var name = metaTag.attr("name");
+    if(name === undefined) {
+      return;
+    }
+
+    var content = metaTag.attr("content");
+    if(content === undefined) {
+      content = "";
+    }
+
+    strongElement = $('<strong></strong>').text(name + " (" + content.length + "): ");
+    textNode = document.createTextNode(content);
+
+    $('<p>').append(strongElement).append(textNode).appendTo(container);
+  });
+
+  $('body').prepend(container);
+}
+
+HighlightComponent.prototype.hideMetaTags = function() {
+  $('#govuk-chrome-toolkit-banner').remove();
+}
 
 HighlightComponent.prototype.sendState = function() {
   chrome.runtime.sendMessage({

--- a/src/highlight-component.js
+++ b/src/highlight-component.js
@@ -2,6 +2,7 @@
 
 function HighlightComponent() {
   this.state = false;
+  this.metaTags = false;
   this.components = extractComponentsFromPage();
 
   function extractComponentsFromPage() {
@@ -40,6 +41,8 @@ function HighlightComponent() {
   chrome.runtime.onMessage.addListener(function (request) {
     if (request.trigger == 'toggleState') {
       this.toggleState();
+    } else if (request.trigger == 'toggleMetaTags') {
+      this.toggleMetaTags();
     }
   }.bind(this));
 }
@@ -54,10 +57,36 @@ HighlightComponent.prototype.toggleState = function () {
   this.sendState();
 }
 
+HighlightComponent.prototype.toggleMetaTags = function () {
+  this.metaTags = !this.metaTags;
+
+  if(this.metaTags) {
+    var msgElm = document.createElement("div");
+    var selectElement = document.getElementsByTagName("title")[0];
+    var msg = "<p><strong>title (" + selectElement.innerHTML.length + "):</strong> " + selectElement.innerHTML + "</p>";
+    var codeSegments = document.getElementsByTagName("meta");
+
+    for (var i=0; i < codeSegments.length;i++) {
+      if (codeSegments[i].getAttribute("name") !== null) {
+        var strs = codeSegments[i].getAttribute("content");
+        msg += "<p><strong>" + codeSegments[i].getAttribute("name") + " (" + strs.length + "):</strong> " + strs + "</p>";
+      }
+    }
+
+    msgElm.innerHTML = '<div id="govuk-chrome-toolkit-banner" style="border:2px solid #000;background:#ffc;text-align:left;padding:1em;">' + msg + "</div>";
+    document.body.insertBefore(msgElm, document.body.firstChild);
+  } else {
+    $('#govuk-chrome-toolkit-banner').remove();
+  }
+
+  this.sendState();
+};
+
 HighlightComponent.prototype.sendState = function() {
   chrome.runtime.sendMessage({
     action: "highlightState",
-    highlightState: this.state
+    highlightState: this.state,
+    metaTags: this.metaTags
   });
 };
 

--- a/src/highlight-component.js
+++ b/src/highlight-component.js
@@ -39,15 +39,15 @@ function HighlightComponent() {
   }
 
   chrome.runtime.onMessage.addListener(function (request) {
-    if (request.trigger == 'toggleState') {
-      this.toggleState();
+    if (request.trigger == 'toggleComponents') {
+      this.toggleComponents();
     } else if (request.trigger == 'toggleMetaTags') {
       this.toggleMetaTags();
     }
   }.bind(this));
 }
 
-HighlightComponent.prototype.toggleState = function () {
+HighlightComponent.prototype.toggleComponents = function () {
   this.state = !this.state;
 
   for (var i = 0; i < this.components.length; i++) {

--- a/src/popup.html
+++ b/src/popup.html
@@ -33,6 +33,9 @@
       <li>
         <a href='#' id='highlight-components'>Highlight Components</a>
       </li>
+      <li>
+        <a href='#' id='highlight-meta-tags'>Show meta tags</a>
+      </li>
       {{#abTests}}
         <li>
           <span class='ab-test-name'>A/B test: <strong>{{testName}}</strong></span>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -116,7 +116,7 @@ var Popup = Popup || {};
 
       chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
         var govukTab = tabs[0];
-        chrome.tabs.sendMessage(govukTab.id, { trigger: 'toggleState' });
+        chrome.tabs.sendMessage(govukTab.id, { trigger: 'toggleComponents' });
       });
     });
 

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -43,6 +43,11 @@ var Popup = Popup || {};
         $('#highlight-components').text('Stop highlighting components');
       else
         $('#highlight-components').text('Highlight Components');
+
+      if (request.metaTags)
+        $('#highlight-meta-tags').text('Hide meta tags');
+      else
+        $('#highlight-meta-tags').text('Show meta tags');
     }
   });
 
@@ -112,6 +117,15 @@ var Popup = Popup || {};
       chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
         var govukTab = tabs[0];
         chrome.tabs.sendMessage(govukTab.id, { trigger: 'toggleState' });
+      });
+    });
+
+    $('#highlight-meta-tags').on('click', function(e) {
+      e.preventDefault();
+
+      chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
+        var govukTab = tabs[0];
+        chrome.tabs.sendMessage(govukTab.id, { trigger: 'toggleMetaTags' });
       });
     });
   }


### PR DESCRIPTION
This adds a button to the plugin for showing meta tags in a banner at the top of the page. It can be used to see what's being sent to google analytics, and what search engines see when crawling the page.

It's equivalent to this bookmarklet: `javascript:(function()%7Bvar d %3D document.createElement(%27div%27)%3Bvar x %3D document.getElementsByTagName(%27title%27)%5B0%5D%3Bvar msg %3D %27<p><strong>title (%27%2Bx.innerHTML.length%2B%27):</strong> %27%2Bx.innerHTML%2B%27</p>%27%3Bvar ms %3D document.getElementsByTagName(%27meta%27)%3Bfor(var i%3D0%3Bi<ms.length%3Bi%2B%2B)%7Bif(null!%3D ms%5Bi%5D.getAttribute(%27name%27))%7Bvar c%3Dms%5Bi%5D.getAttribute(%27content%27)%3Bmsg%2B%3D%27<p><strong>%27%2Bms%5Bi%5D.getAttribute(%27name%27)%2B%27 (%27%2Bc.length%2B%27):</strong> %27%2Bc%2B%27</p>%27%3B%7D%7Ddocument.body.insertBefore(d,document.body.firstChild)%3Bd.innerHTML%3D%27<div style%3D"border:2px solid %23000%3Bbackground:%23ffc%3Btext-align:left%3Bpadding:1em%3B"><a href%3D"%23" onclick%3D"document.body.removeChild(document.body.firstChild)%3Breturn false">remove</a>%27%2Bmsg%2B%27</div>%27%3B%7D)()`

The design is not amazing, but I'd rather render this on the page than try and fit it into the popup, because there can be a lot of them, and there is some overlap with information that's already in the popup, but I want to make it clear what's a meta tag and what isn't.

<img width="1406" alt="screen shot 2018-01-11 at 16 23 22" src="https://user-images.githubusercontent.com/87579/34835122-d44ad760-f6eb-11e7-93ce-9f70f3c9348a.png">


Trello: https://trello.com/c/TDeqykiP/106-add-gov-a-lytics-to-the-govuk-toolkit-chrome-extension