### PR TITLE
Stop links opening twice

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -99,6 +99,8 @@ var Popup = Popup || {};
         return;
       }
 
+      e.preventDefault();
+
       chrome.tabs.update(null, { url: $(this).attr('href') });
 
       // This will provide us with a `location` object just like `window.location`.


### PR DESCRIPTION
This commit prevents Firefox from opening certain links in both the current tab and a new tab by preventing the default link behaviour, allowing the custom behaviour to open the link in the current tab.

Fixes https://github.com/alphagov/govuk-toolkit-chrome/issues/96