### PR TITLE
Add proper focus color

### DIFF
--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -14,6 +14,7 @@ body {
   color: #fff;
   padding: 15px 8px;
   display: inline-block;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0.3);
 }
 
 .envs a.current,
@@ -36,6 +37,13 @@ li a {
   padding: 7px 10px;
   color: #000;
   text-decoration: none;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0.3);
+}
+
+li a:focus,
+.envs a:focus {
+  background-color: #ffbf47;
+  outline: 3px solid #ffbf47;
 }
 
 li a img {


### PR DESCRIPTION
This adds a yellow background for focussed items. It's meant to make the extension more accessible, because it really isn't clear that you're able to tab through the menu items.

Brought to my attention by Marian in the content team.