### PR TITLE
Attempt to force a scrollbar when the extension doesn't fit on screen

### DIFF
--- a/src/fetch-page-data.js
+++ b/src/fetch-page-data.js
@@ -10,6 +10,7 @@ chrome.runtime.sendMessage({
   currentPathname: window.location.pathname,
   renderingApplication: getMetatag('govuk:rendering-application'),
   abTestBuckets: getAbTestBuckets(),
+  windowHeight: window.innerHeight,
   highlightState: window.highlightComponent.state
 });
 

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -70,3 +70,7 @@ li a:hover {
   color: #fff;
   background-color: #005ea5;
 }
+
+#content {
+  overflow-y: scroll;
+}

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -30,6 +30,7 @@ var Popup = Popup || {};
         request.currentOrigin,
         request.currentPathname,
         request.renderingApplication,
+        request.windowHeight,
         abTestBuckets
       );
     }
@@ -52,11 +53,15 @@ var Popup = Popup || {};
   });
 
   // Render the popup.
-  function renderPopup(location, host, origin, pathname, renderingApplication, abTestBuckets) {
+  function renderPopup(location, host, origin, pathname, renderingApplication, windowHeight, abTestBuckets) {
     // Creates a view object with the data and render a template with it.
     var view = createView(location, host, origin, pathname, renderingApplication, abTestBuckets);
 
     var contentStore = view.contentLinks.find(function (el) { return el.name == "Content item (JSON)" })
+
+    if (windowHeight < 600) {
+      $('#content').css({ height: windowHeight + "px" })
+    }
 
     if (contentStore) {
       // Request the content item to add some extra links.


### PR DESCRIPTION
Someone in the content team wants to use the extension but uses screen magnification. This causes the extension window to fall off the screen. Because the height is set you can't scroll.

![image](https://user-images.githubusercontent.com/233676/37041556-63137b90-2154-11e8-8689-1b344c9825a9.png)

This PR attempts to remedy the issue by setting the height of the extension if the user's browser window is lower than 600 (the max height of the popup).

We now gain a scrollbar on the popup but that's an acceptable price to pay.  

## Before

![screen shot 2018-03-06 at 15 38 48](https://user-images.githubusercontent.com/233676/37041602-81762ace-2154-11e8-9644-b276ff93d704.png)

## After

<img width="1213" alt="screen shot 2018-03-06 at 15 38 46" src="https://user-images.githubusercontent.com/233676/37041611-8864aea0-2154-11e8-86dd-f141dbee4c8c.png">
