### PR TITLE
Only show scrollbars when we're scrolly

### DIFF
--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -70,7 +70,3 @@ li a:hover {
   color: #fff;
   background-color: #005ea5;
 }
-
-#content {
-  overflow-y: scroll;
-}

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -60,7 +60,7 @@ var Popup = Popup || {};
     var contentStore = view.contentLinks.find(function (el) { return el.name == "Content item (JSON)" })
 
     if (windowHeight < 600) {
-      $('#content').css({ height: windowHeight + "px" })
+      $('#content').css({ height: windowHeight + "px", 'overflow-y': 'scroll' })
     }
 
     if (contentStore) {


### PR DESCRIPTION
This prevents the scrollbar from showing when there's nothing to scroll. Hat tip @maxgds.